### PR TITLE
Only support unsigned ints for slice indexes

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -44,7 +44,7 @@ func ExtractParameter(s string, params interface{}) (string, bool) {
 		if paramsValueSliceLength := paramsValue.Len(); paramsValueSliceLength > 0 {
 
 			if p := strings.SplitN(s, ".", 2); len(p) > 1 {
-				index, err := strconv.ParseInt(p[0], 10, 64)
+				index, err := strconv.ParseUint(p[0], 10, 64)
 
 				if err != nil {
 					return "", false


### PR DESCRIPTION
This commit changes ExtractParameter to parse slice indexes as unsigned
ints.  Fixes test case "a.-1.b".