### PR TITLE
Fix reverse build tag in webhook_windows.go

### DIFF
--- a/webhook_windows.go
+++ b/webhook_windows.go
@@ -1,5 +1,3 @@
-//+build !windows
-
 package main
 
 import (


### PR DESCRIPTION
9c545a745f4d8b778a7ec3f055cf55645f8cd52c accidentally started negating
the build constraint in webhook_windows.go. The build tag isn't actually
necessary because of the filename, so this removes it and fixes the
Windows build.