### PR TITLE
Add environment arguments and improve testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ If you use Slack, you can set up an "Outgoing webhook integration" to run variou
  1. receive the request,
  2. parse the headers, payload and query variables,
  3. check if the specified rules for the hook are satisfied,
- 3. and finally, pass the specified arguments to the specified command.
+ 3. and finally, pass the specified arguments to the specified command via
+    command line arguments or via environment variables.
 
 Everything else is the responsibility of the command's author.
 

--- a/hook/hook_test.go
+++ b/hook/hook_test.go
@@ -123,7 +123,7 @@ var hookExtractCommandArgumentsTests = []struct {
 }{
 	{"test", []Argument{Argument{"header", "a"}}, &map[string]interface{}{"a": "z"}, nil, nil, []string{"test", "z"}, true},
 	// failures
-	{"fail", []Argument{Argument{"payload", "a"}}, &map[string]interface{}{"a": "z"}, nil, nil, []string{"fail", ""}, false},
+	{"fail", []Argument{Argument{"payload", "a"}}, &map[string]interface{}{"a": "z"}, nil, nil, []string{"fail"}, false},
 }
 
 func TestHookExtractCommandArguments(t *testing.T) {
@@ -188,8 +188,8 @@ var matchRuleTests = []struct {
 	// failures
 	{"value", "", "", "X", Argument{"header", "a"}, &map[string]interface{}{"a": "z"}, nil, nil, []byte{}, false, false},
 	{"regex", "^X", "", "", Argument{"header", "a"}, &map[string]interface{}{"a": "z"}, nil, nil, []byte{}, false, false},
+	{"value", "", "2", "X", Argument{"header", "a"}, &map[string]interface{}{"y": "z"}, nil, nil, []byte{}, false, false}, // reference invalid header
 	// errors
-	{"value", "", "2", "X", Argument{"header", "a"}, &map[string]interface{}{"y": "z"}, nil, nil, []byte{}, false, true},                // reference invalid header
 	{"regex", "*", "", "", Argument{"header", "a"}, &map[string]interface{}{"a": "z"}, nil, nil, []byte{}, false, true},                 // invalid regex
 	{"payload-hash-sha1", "", "secret", "", Argument{"header", "a"}, &map[string]interface{}{"a": ""}, nil, nil, []byte{}, false, true}, // invalid hmac
 }
@@ -262,7 +262,7 @@ var andRuleTests = []struct {
 		"invalid rule",
 		AndRule{{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a"}}}},
 		&map[string]interface{}{"y": "z"}, nil, nil, nil,
-		false, true,
+		false, false,
 	},
 }
 
@@ -317,7 +317,7 @@ var orRuleTests = []struct {
 			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a"}}},
 		},
 		&map[string]interface{}{"y": "Z"}, nil, nil, []byte{},
-		false, true,
+		false, false,
 	},
 }
 

--- a/test/hookecho.go
+++ b/test/hookecho.go
@@ -1,0 +1,26 @@
+// Hook Echo is a simply utility used for testing the Webhook package.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func main() {
+	if len(os.Args) > 1 {
+		fmt.Printf("arg: %s\n", strings.Join(os.Args[1:], " "))
+	}
+
+	var env []string
+	for _, v := range os.Environ() {
+		if strings.HasPrefix(v, "HOOK_") {
+			env = append(env, v)
+		}
+	}
+
+	if len(env) > 0 {
+		fmt.Printf("env: %s\n", strings.Join(env, " "))
+	}
+}

--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -1,9 +1,16 @@
 [
   {
     "id": "github",
-    "execute-command": "/bin/echo",
+    "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",
     "include-command-output-in-response": true,
+    "pass-environment-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "pusher.email"
+      }
+    ],
     "pass-arguments-to-command":
     [
       {
@@ -52,7 +59,7 @@
   },
   {
     "id": "bitbucket",
-    "execute-command": "/bin/echo",
+    "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",
     "include-command-output-in-response": true,
     "response-message": "success",
@@ -99,7 +106,7 @@
   },
   {
     "id": "gitlab",
-    "execute-command": "/bin/echo",
+    "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",
     "response-message": "success",
     "include-command-output-in-response": true,
@@ -133,3 +140,4 @@
     }
   }
 ]
+

--- a/webhook.go
+++ b/webhook.go
@@ -234,13 +234,20 @@ func handleHook(h *hook.Hook, headers, query, payload *map[string]interface{}, b
 
 	cmd := exec.Command(h.ExecuteCommand)
 	cmd.Dir = h.CommandWorkingDirectory
+
 	cmd.Args, err = h.ExtractCommandArguments(headers, query, payload)
 	if err != nil {
 		log.Printf("error extracting command arguments: %s", err)
 		return ""
 	}
 
-	log.Printf("executing %s (%s) with arguments %s using %s as cwd\n", h.ExecuteCommand, cmd.Path, cmd.Args, cmd.Dir)
+	cmd.Env, err = h.ExtractCommandArgumentsForEnv(headers, query, payload)
+	if err != nil {
+		log.Printf("error extracting command arguments: %s", err)
+		return ""
+	}
+
+	log.Printf("executing %s (%s) with arguments %s and environment %s using %s as cwd\n", h.ExecuteCommand, cmd.Path, cmd.Args, cmd.Env, cmd.Dir)
 
 	out, err := cmd.CombinedOutput()
 


### PR DESCRIPTION
There's a lot in this commit.

 1. Add `pass-environment-to-command` option that works much like
 `pass-arguments-to-command`.  You can see an example usage in the
 "github" test case.

 2. Add a test program called "hookecho" that is used to test the
 webhook package instead of relying upon a system `echo` command.

 3. Move hooks_test.json to a template so that we can update the path to
 hookecho on the fly.

 4. Don't return an error at the end of hook.MatchRule.Evaluate().  All
 tests succeed for me now.