### PR TITLE
dir-feat: Make loading from directory recursively possible

### DIFF
--- a/test/hooks_dir.test/depth1/depth2/hooks.json.example
+++ b/test/hooks_dir.test/depth1/depth2/hooks.json.example
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "webhook-d2",
+    "execute-command": "/home/adnan/redeploy-go-webhook.sh",
+    "command-working-directory": "/home/adnan/go",
+    "response-message": "I got the payload!",
+    "response-headers":
+    [
+      {
+        "name": "Access-Control-Allow-Origin",
+        "value": "*"
+      }
+    ],
+    "pass-arguments-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "head_commit.id"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.name"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.email"
+      }
+    ],
+    "trigger-rule":
+    {
+      "and":
+      [
+        {
+          "match":
+          {
+            "type": "payload-hash-sha1",
+            "secret": "mysecret",
+            "parameter":
+            {
+              "source": "header",
+              "name": "X-Hub-Signature"
+            }
+          }
+        },
+        {
+          "match":
+          {
+            "type": "value",
+            "value": "refs/heads/master",
+            "parameter":
+            {
+              "source": "payload",
+              "name": "ref"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "simple-webhook-d2",
+    "execute-command": "/tmp/script1.sh",
+    "pass-arguments-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "head_commit.id"
+      },
+      {
+        "source": "payload",
+        "name": "head_commit.author.name"
+      },
+      {
+        "source": "payload",
+        "name": "head_commit.author.email"
+      }
+    ]
+  }
+]

--- a/test/hooks_dir.test/depth1/hooks.json.example
+++ b/test/hooks_dir.test/depth1/hooks.json.example
@@ -1,0 +1,79 @@
+[
+  {
+    "id": "webhook",
+    "execute-command": "/home/adnan/redeploy-go-webhook.sh",
+    "command-working-directory": "/home/adnan/go",
+    "response-message": "I got the payload!",
+    "response-headers":
+    [
+      {
+        "name": "Access-Control-Allow-Origin",
+        "value": "*"
+      }
+    ],
+    "pass-arguments-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "head_commit.id"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.name"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.email"
+      }
+    ],
+    "trigger-rule":
+    {
+      "and":
+      [
+        {
+          "match":
+          {
+            "type": "payload-hash-sha1",
+            "secret": "mysecret",
+            "parameter":
+            {
+              "source": "header",
+              "name": "X-Hub-Signature"
+            }
+          }
+        },
+        {
+          "match":
+          {
+            "type": "value",
+            "value": "refs/heads/master",
+            "parameter":
+            {
+              "source": "payload",
+              "name": "ref"
+            }
+          }
+        }
+      ]
+    }
+  },
+  {
+    "id": "simple-webhook",
+    "execute-command": "/tmp/script1.sh",
+    "pass-arguments-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "head_commit.id"
+      },
+      {
+        "source": "payload",
+        "name": "head_commit.author.name"
+      },
+      {
+        "source": "payload",
+        "name": "head_commit.author.email"
+      }
+    ]
+  }
+]

--- a/test/hooks_dir.test/depth1b/hooks-invalid.json.example
+++ b/test/hooks_dir.test/depth1b/hooks-invalid.json.example
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "webhook",
+    "execute-command": "/home/adnan/redeploy-go-webhook.sh",
+    "command-working-directory": "/home/adnan/go",
+    "response-message": "I got the payload!",
+    "response-headers":
+    [
+        "value": "*"
+      }
+    ],
+    "pass-arguments-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "head_commit.id"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.name"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.email"
+      },
+    ],
+    "trigger-rule":
+    {
+      "and":
+      [
+        {
+          "match":
+          {
+            "type": "payload-hash-sha1",
+            "secret": "mysecret",
+            "parameter":
+            {
+#
+#
+#        
+      "source": "header",
+              "name": "X-Hub-Signature"
+            }
+          }
+        },
+        {
+          "match":
+          {
+            "type": "value",
+            "value": "refs/heads/master",
+            "parameter":
+            {
+              "source": "payload",
+              "name": "ref"
+  {
+    "id": "simple-webhook",
+    "execute-command": "/tmp/script1.sh",
+    "pass-arguments-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "head_commit.id"
+      },
+      {
+        "source": "payload",
+        "name": "head_commit.author.name"
+      },
+      {
+        "source": "payload",
+        "name": "head_commit.author.email"
+      }
+    ]
+  }
+]]]];


### PR DESCRIPTION
The commit adds the following modifications:
 * Possibility to load hooks recursively from a directory
 * Extraction of the loadinghook method in webhook.go
 * Tests done on a fairly complex tree of directory

Allowing hooks to be loaded from a directory is a nice feature, as it
allows a better organisation/readibility of the hooks that we have.

The LoadFromDir method rely on LoadFromFile and is meant to be very
permissive, and will return errors only when no hooks have been loaded.
Otherwise it will simply return 'nil' and the potential issues/warnings
that happen during the loading of hooks (invalid file, invalid path,
issue opening, etc).

Not convinced the testing of directory is as it should be, but I added the
"directory testing structure" in the test/ directory, thought it was the most
appropriate.

Note:
This does NOT have hotreload. Not sure it made sense as watchers would have to be used for each file/directory, same if new ones were added. There was a discussion about having recursive watcher, but that was a long time ago. If the project is used externally then recalling `loadHooks` or `reloadHooks` (and include dir loading) might make more sense.