### PR TITLE
Makefile cross-platform binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+OS = darwin freebsd linux openbsd windows
+ARCHS = 386 arm amd64 arm64
+
+all: build release
+
+build: deps
+	go build
+
+release: clean deps
+	@for arch in $(ARCHS);\
+	do \
+		for os in $(OS);\
+		do \
+			echo "Building $$os-$$arch"; \
+			mkdir -p build/webhook-$$os-$$arch/; \
+			GOOS=$$os GOARCH=$$arch go build -o build/webhook-$$os-$$arch/webhook; \
+			tar cz -C build -f build/webhook-$$os-$$arch.tar.gz webhook-$$os-$$arch; \
+		done \
+	done
+
+test: deps
+	go test ./...
+
+deps:
+	go get -d -v -t ./...
+
+clean:
+	rm -rf build
+	rm -f webhook


### PR DESCRIPTION
Makefile script build binaries for many platforms and shrinks in `tar.gz` archives.

```bash
% make
go get -d -v -t ./...
go build
rm -rf build
rm -f webhook
Building darwin-386
Building freebsd-386
Building linux-386
Building windows-386
Building darwin-amd64
Building freebsd-amd64
Building linux-amd64
Building windows-amd64

% ls -1 build/*.tar.gz
build/webhook-darwin-386.tar.gz
build/webhook-darwin-amd64.tar.gz
build/webhook-freebsd-386.tar.gz
build/webhook-freebsd-amd64.tar.gz
build/webhook-linux-386.tar.gz
build/webhook-linux-amd64.tar.gz
build/webhook-windows-386.tar.gz
build/webhook-windows-amd64.tar.gz
```

* [Travis-CI — GitHub Releases Uploading](https://docs.travis-ci.com/user/deployment/releases)
* [Travis-CI — Defining Variables in Repository Settings](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings)
* [`adnanh/webhook-contrib`](https://github.com/adnanh/webhook-contrib)
* [PackageCloud — Deploy .rpm & .deb](https://packagecloud.io/)
* [Packager — Deploy .rpm & .deb](https://packager.io/)
* [Bintray — Automated software distribution](https://bintray.com/)
* https://golang.org/doc/install/source#environment
