### PR TITLE
make http return code for mismatch rules configurable

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -290,17 +290,17 @@ func (h *ResponseHeaders) Set(value string) error {
 
 // Hook type is a structure containing details for a single hook
 type Hook struct {
-	ID                       string          `json:"id,omitempty"`
-	ExecuteCommand           string          `json:"execute-command,omitempty"`
-	CommandWorkingDirectory  string          `json:"command-working-directory,omitempty"`
-	ResponseMessage          string          `json:"response-message,omitempty"`
-	ResponseHeaders          ResponseHeaders `json:"response-headers,omitempty"`
-	CaptureCommandOutput     bool            `json:"include-command-output-in-response,omitempty"`
-	PassEnvironmentToCommand []Argument      `json:"pass-environment-to-command,omitempty"`
-	PassArgumentsToCommand   []Argument      `json:"pass-arguments-to-command,omitempty"`
-	JSONStringParameters     []Argument      `json:"parse-parameters-as-json,omitempty"`
-	TriggerRule              *Rules          `json:"trigger-rule,omitempty"`
-	TriggerRuleMismatchCode  int             `json:"trigger-rule-mismatch-code,omitempty"`
+	ID                                  string          `json:"id,omitempty"`
+	ExecuteCommand                      string          `json:"execute-command,omitempty"`
+	CommandWorkingDirectory             string          `json:"command-working-directory,omitempty"`
+	ResponseMessage                     string          `json:"response-message,omitempty"`
+	ResponseHeaders                     ResponseHeaders `json:"response-headers,omitempty"`
+	CaptureCommandOutput                bool            `json:"include-command-output-in-response,omitempty"`
+	PassEnvironmentToCommand            []Argument      `json:"pass-environment-to-command,omitempty"`
+	PassArgumentsToCommand              []Argument      `json:"pass-arguments-to-command,omitempty"`
+	JSONStringParameters                []Argument      `json:"parse-parameters-as-json,omitempty"`
+	TriggerRule                         *Rules          `json:"trigger-rule,omitempty"`
+	TriggerRuleMismatchHttpResponseCode int             `json:"trigger-rule-mismatch-http-response-code,omitempty"`
 }
 
 // ParseJSONParameters decodes specified arguments to JSON objects and replaces the

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -300,6 +300,7 @@ type Hook struct {
 	PassArgumentsToCommand   []Argument      `json:"pass-arguments-to-command,omitempty"`
 	JSONStringParameters     []Argument      `json:"parse-parameters-as-json,omitempty"`
 	TriggerRule              *Rules          `json:"trigger-rule,omitempty"`
+	TriggerRuleMismatchCode  int             `json:"trigger-rule-mismatch-code,omitempty"`
 }
 
 // ParseJSONParameters decodes specified arguments to JSON objects and replaces the

--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -4,7 +4,7 @@
     "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",
     "include-command-output-in-response": true,
-    "trigger-rule-mismatch-code": 400,
+    "trigger-rule-mismatch-http-response-code": 400,
     "pass-environment-to-command":
     [
       {
@@ -60,7 +60,7 @@
     "command-working-directory": "/",
     "include-command-output-in-response": false,
     "response-message": "success",
-    "trigger-rule-mismatch-code": 999,
+    "trigger-rule-mismatch-http-response-code": 999,
     "parse-parameters-as-json": [
       {
         "source": "payload",

--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -4,6 +4,7 @@
     "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",
     "include-command-output-in-response": true,
+    "trigger-rule-mismatch-code": 400,
     "pass-environment-to-command":
     [
       {
@@ -59,6 +60,7 @@
     "command-working-directory": "/",
     "include-command-output-in-response": false,
     "response-message": "success",
+    "trigger-rule-mismatch-code": 999,
     "parse-parameters-as-json": [
       {
         "source": "payload",

--- a/webhook.go
+++ b/webhook.go
@@ -243,13 +243,13 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 		}
 
 		// Check if a return code is configured for the hook
-		if matchedHook.TriggerRuleMismatchCode != 0 {
+		if matchedHook.TriggerRuleMismatchHttpResponseCode != 0 {
 			// Check if the configured return code is supported by the http package
 			// by testing if there is a StatusText for this code.
-			if len(http.StatusText(matchedHook.TriggerRuleMismatchCode)) > 0 {
-				w.WriteHeader(matchedHook.TriggerRuleMismatchCode)
+			if len(http.StatusText(matchedHook.TriggerRuleMismatchHttpResponseCode)) > 0 {
+				w.WriteHeader(matchedHook.TriggerRuleMismatchHttpResponseCode)
 			} else {
-				log.Printf("%s got matched, but the configured return code %d is unknown - defaulting to 200\n", matchedHook.ID, matchedHook.TriggerRuleMismatchCode)
+				log.Printf("%s got matched, but the configured return code %d is unknown - defaulting to 200\n", matchedHook.ID, matchedHook.TriggerRuleMismatchHttpResponseCode)
 			}
 		}
 

--- a/webhook.go
+++ b/webhook.go
@@ -242,6 +242,17 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
+		// Check if a return code is configured for the hook
+		if matchedHook.TriggerRuleMismatchCode != 0 {
+			// Check if the configured return code is supported by the http package
+			// by testing if there is a StatusText for this code.
+			if len(http.StatusText(matchedHook.TriggerRuleMismatchCode)) > 0 {
+				w.WriteHeader(matchedHook.TriggerRuleMismatchCode)
+			} else {
+				log.Printf("%s got matched, but the configured return code %d is unknown - defaulting to 200\n", matchedHook.ID, matchedHook.TriggerRuleMismatchCode)
+			}
+		}
+
 		// if none of the hooks got triggered
 		log.Printf("%s got matched, but didn't get triggered because the trigger rules were not satisfied\n", matchedHook.ID)
 

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -515,5 +515,10 @@ env: HOOK_head_commit.timestamp=2013-03-12T08:14:29-07:00
 `,
 	},
 
-	{"empty payload", "github", nil, `{}`, false, http.StatusOK, `Hook rules were not satisfied.`},
+	// test with custom return code
+	{"empty payload", "github", nil, `{}`, false, http.StatusBadRequest, `Hook rules were not satisfied.`},
+	// test with custom invalid http code, should default to 200 OK
+	{"empty payload", "bitbucket", nil, `{}`, false, http.StatusOK, `Hook rules were not satisfied.`},
+	// test with no configured http return code, should default to 200 OK
+	{"empty payload", "gitlab", nil, `{}`, false, http.StatusOK, `Hook rules were not satisfied.`},
 }


### PR DESCRIPTION
Hi,

we'd like to be able to easily check if a hook was successfully executed. If the hook rules were not satisfied, webhook should return a non-200 HTTP code. I think non-matching hook rules are likely a result of a "Bad Request", so this should be returned instead of 200.