### PR TITLE
Add IP whitelist match rule

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -243,7 +243,7 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 		if matchedHook.TriggerRule == nil {
 			ok = true
 		} else {
-			ok, err = matchedHook.TriggerRule.Evaluate(&headers, &query, &payload, &body)
+			ok, err = matchedHook.TriggerRule.Evaluate(&headers, &query, &payload, &body, r.RemoteAddr)
 			if err != nil {
 				msg := fmt.Sprintf("error evaluating hook: %s", err)
 				log.Printf(msg)


### PR DESCRIPTION
My project [docker-nginx-unit-hugo](https://github.com/handcraftedbits/docker-nginx-unit-hugo) makes use of webhook for doing automatic Hugo site rebuilds upon GitHub or GitLab commit pushes.  I would like to support Bitbucket but unfortunately they have no support for sending back a secret token when their webhook fires.  I know that technically this project supports Bitbucket webhooks in the sense that you can [create a webhook that does no actual verification that Bitbucket is actually the initiator](https://github.com/adnanh/webhook/wiki/Hook-Examples#incoming-bitbucket-webhook), but that's really not very safe.

[According to Bitbucket's docs](https://confluence.atlassian.com/bitbucket/manage-webhooks-735643732.html#Managewebhooks-trigger_webhook), the preferred method to verify that the webhook really came from Bitbucket is to whitelist an IP range.  Since webhook doesn't have an IP whitelist MatchRule, I created one.  It's rather simple, here's what an example `trigger-rule` looks like:

```json
"trigger-rule": {
  "match": {
    "type": "ip-whitelist",
    "ip-range": "192.168.0.1/24"
  }
}
```

`ip-range` can either be a single IPv4/6 IP address or a range of addresses in [CIDR notation](https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing#CIDR_notation).  There is no `parameter` that needs to be specified.

I can update the wiki if/when this pull request is accepted.  Thanks!