### PR TITLE
Add prebuilt binaries to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,9 @@ to get the latest version of the [webhook](https://github.com/adnanh/webhook/).
 #### Debian "sid"
 If you are using unstable version of Debian linux ("sid"), you can install webhook using `apt-get install webhook` which will install community packaged version (thanks [@freeekanayaka](https://github.com/freeekanayaka)) from https://packages.debian.org/sid/webhook
 
+### Download prebuilt binaries
+Prebuilt binaries for different architectures are available at [GitHub Releases](https://github.com/adnanh/webhook/releases).
+
 ## Configuration
 Next step is to define some hooks you want [webhook](https://github.com/adnanh/webhook/) to serve. Begin by creating an empty file named `hooks.json`. This file will contain an array of hooks the [webhook](https://github.com/adnanh/webhook/) will serve. Check [Hook definition page](https://github.com/adnanh/webhook/wiki/Hook-Definition) to see the detailed description of what properties a hook can contain, and how to use them.
 


### PR DESCRIPTION
Link to prebuilt binaries should be available in readme.md for users who don't have Go installed and just want things to work.

Btw, this project works so well. Thanks for the hard work.