### PR TITLE
Use the github.com/ghodss/yaml library to unserialize webhooks.

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -15,6 +15,8 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/ghodss/yaml"
 )
 
 // Constants used to specify the parameter source
@@ -503,7 +505,7 @@ func (h *Hooks) LoadFromFile(path string) error {
 		return e
 	}
 
-	e = json.Unmarshal(file, h)
+	e = yaml.Unmarshal(file, h)
 	return e
 }
 

--- a/hook/hook_test.go
+++ b/hook/hook_test.go
@@ -233,6 +233,7 @@ var hooksLoadFromFileTests = []struct {
 	ok   bool
 }{
 	{"../hooks.json.example", true},
+    {"../hooks.yaml.example", true},
 	{"", true},
 	// failures
 	{"missing.json", false},

--- a/hooks.yaml.example
+++ b/hooks.yaml.example
@@ -1,0 +1,28 @@
+- id: webhook
+  execute-command: /home/adnan/redeploy-go-webhook.sh
+  command-working-directory: /home/adnan/go
+  response-message: I got the payload!
+  response-headers:
+  - name: Access-Control-Allow-Origin
+    value: '*'
+  pass-arguments-to-command:
+  - source: payload
+    name: head_commit.id
+  - source: payload
+    name: pusher.name
+  - source: payload
+    name: pusher.email
+  trigger-rule:
+    and:
+    - match:
+        type: payload-hash-sha1
+        secret: mysecret
+        parameter:
+          source: header
+          name: X-Hub-Signature
+    - match:
+        type: value
+        value: refs/heads/master
+        parameter:
+          source: payload
+          name: ref

--- a/test/hooks.yaml.tmpl
+++ b/test/hooks.yaml.tmpl
@@ -1,0 +1,75 @@
+- trigger-rule:
+    and:
+    - match:
+        parameter:
+          source: header
+          name: X-Hub-Signature
+        secret: mysecret
+        type: payload-hash-sha1
+    - match:
+        parameter:
+          source: payload
+          name: ref
+        type: value
+        value: refs/heads/master
+  include-command-output-in-response: true
+  trigger-rule-mismatch-http-response-code: 400
+  execute-command: '{{ .Hookecho }}'
+  pass-arguments-to-command:
+  - source: payload
+    name: head_commit.id
+  - source: payload
+    name: head_commit.author.email
+  pass-environment-to-command:
+  - source: payload
+    name: head_commit.timestamp
+  id: github
+  command-working-directory: /
+- trigger-rule:
+    and:
+    - match:
+        parameter:
+          source: payload
+          name: payload.canon_url
+        type: value
+        value: https://bitbucket.org
+    - match:
+        parameter:
+          source: payload
+          name: payload.repository.absolute_url
+        type: value
+        value: /webhook/testing/
+    - match:
+        parameter:
+          source: payload
+          name: payload.commits.0.branch
+        type: value
+        value: master
+  parse-parameters-as-json:
+  - source: payload
+    name: payload
+  trigger-rule-mismatch-http-response-code: 999
+  execute-command: '{{ .Hookecho }}'
+  response-message: success
+  include-command-output-in-response: false
+  id: bitbucket
+  command-working-directory: /
+- trigger-rule:
+    match:
+      parameter:
+        source: payload
+        name: ref
+      type: value
+      value: refs/heads/master
+  pass-arguments-to-command:
+  - source: payload
+    name: commits.0.id
+  - source: payload
+    name: user_name
+  - source: payload
+    name: user_email
+  execute-command: '{{ .Hookecho }}'
+  response-message: success
+  include-command-output-in-response: true
+  id: gitlab
+  command-working-directory: /


### PR DESCRIPTION
This supports both JSON and YAML seamlessly, providing for an easier human parseable format on disk.

Closes #142.

Since this depends on external library, and I'm not sure how the project handles vendoring at the moment so I've left that as an unsolved issue just now (my personal favorite tool is govendor).