### PR TITLE
Change to CombinedOutput to consume Stderr as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ If you don't have time to waste configuring, hosting, debugging and maintaining 
 
 For example, if you're using Github or Bitbucket, you can use [webhook](https://github.com/adnanh/webhook/) to set up a hook that runs a redeploy script for your project on your staging server, whenever you push changes to the master branch of your project.
 
-If you use Slack, you can set up an "Outgoing webhook integration" to run various commands on your server, which can then report back directly to your Slack channels using the "Incoming webhook integrations".
+If you use Mattermost or Slack, you can set up an "Outgoing webhook integration" or "Slash command" to run various commands on your server, which can then report back directly to you or your channels using the "Incoming webhook integrations", or the appropriate response body.
 
 [webhook](https://github.com/adnanh/webhook/) aims to do nothing more than it should do, and that is:
  1. receive the request,

--- a/webhook.go
+++ b/webhook.go
@@ -326,7 +326,7 @@ func handleHook(h *hook.Hook, headers, query, payload *map[string]interface{}, b
 
 	log.Printf("executing %s (%s) with arguments %q and environment %s using %s as cwd\n", h.ExecuteCommand, cmd.Path, cmd.Args, envs, cmd.Dir)
 
-	out, err := cmd.Output()
+	out, err := cmd.CombinedOutput()
 
 	log.Printf("command output: %s\n", out)
 


### PR DESCRIPTION
First off thank you for this awesome work. It's been super easy to get the (usually) really hard stuff set up with this tool!

I did run into one issue where I thought things could be improved a bit though. One of my hooks runs a small go binary and in that binary errors are written to `os.Stderr` and when testing I noticed that it was failing with no feedback other than "exited with error code $code" which was not terribly helpful. I checked the code and noticed you were using `Cmd.Output()` which only grabs `os.Stdout` by default.

I've submitted this pull request changing that behavior to use [CombinedOutput](https://golang.org/pkg/os/exec/#Cmd.CombinedOutput) which consumes both stderr and stdout.  Hopefully that doesn't make the output too verbose but I was easily able to discover the problem in my code upon changing it and so I thought others might benefit as well.

Thank you again!