### PR TITLE
Allow hooks file to be parsed as a template

### DIFF
--- a/hooks.json.tmpl.example
+++ b/hooks.json.tmpl.example
@@ -1,0 +1,60 @@
+[
+  {
+    "id": "webhook",
+    "execute-command": "/home/adnan/redeploy-go-webhook.sh",
+    "command-working-directory": "/home/adnan/go",
+    "response-message": "I got the payload!",
+    "response-headers":
+    [
+      {
+        "name": "Access-Control-Allow-Origin",
+        "value": "*"
+      }
+    ],
+    "pass-arguments-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "head_commit.id"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.name"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.email"
+      }
+    ],
+    "trigger-rule":
+    {
+      "and":
+      [
+        {
+          "match":
+          {
+            "type": "payload-hash-sha1",
+            "secret": "{{ getenv "XXXTEST_SECRET" | js }}",
+            "parameter":
+            {
+              "source": "header",
+              "name": "X-Hub-Signature"
+            }
+          }
+        },
+        {
+          "match":
+          {
+            "type": "value",
+            "value": "refs/heads/master",
+            "parameter":
+            {
+              "source": "payload",
+              "name": "ref"
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/hooks.yaml.tmpl.example
+++ b/hooks.yaml.tmpl.example
@@ -1,0 +1,28 @@
+- id: webhook
+  execute-command: /home/adnan/redeploy-go-webhook.sh
+  command-working-directory: /home/adnan/go
+  response-message: I got the payload!
+  response-headers:
+  - name: Access-Control-Allow-Origin
+    value: '*'
+  pass-arguments-to-command:
+  - source: payload
+    name: head_commit.id
+  - source: payload
+    name: pusher.name
+  - source: payload
+    name: pusher.email
+  trigger-rule:
+    and:
+    - match:
+        type: payload-hash-sha1
+        secret: "{{ getenv "XXXTEST_SECRET" | js }}"
+        parameter:
+          source: header
+          name: X-Hub-Signature
+    - match:
+        type: value
+        value: refs/heads/master
+        parameter:
+          source: payload
+          name: ref

--- a/webhook.go
+++ b/webhook.go
@@ -34,6 +34,7 @@ var (
 	hotReload          = flag.Bool("hotreload", false, "watch hooks file for changes and reload them automatically")
 	hooksURLPrefix     = flag.String("urlprefix", "hooks", "url prefix to use for served hooks (protocol://yourserver:port/PREFIX/:hook-id)")
 	secure             = flag.Bool("secure", false, "use HTTPS instead of HTTP")
+	asTemplate         = flag.Bool("template", false, "parse hooks file as a Go template")
 	cert               = flag.String("cert", "cert.pem", "path to the HTTPS certificate pem file")
 	key                = flag.String("key", "key.pem", "path to the HTTPS certificate private key pem file")
 	justDisplayVersion = flag.Bool("version", false, "display webhook version and quit")
@@ -99,7 +100,7 @@ func main() {
 
 		newHooks := hook.Hooks{}
 
-		err := newHooks.LoadFromFile(hooksFilePath)
+		err := newHooks.LoadFromFile(hooksFilePath, *asTemplate)
 
 		if err != nil {
 			log.Printf("couldn't load hooks from file! %+v\n", err)
@@ -407,7 +408,7 @@ func reloadHooks(hooksFilePath string) {
 	// parse and swap
 	log.Printf("attempting to reload hooks from %s\n", hooksFilePath)
 
-	err := hooksInFile.LoadFromFile(hooksFilePath)
+	err := hooksInFile.LoadFromFile(hooksFilePath, *asTemplate)
 
 	if err != nil {
 		log.Printf("couldn't load hooks from file! %+v\n", err)


### PR DESCRIPTION
Add a -template command line option that instructs webhook to parse the hooks files as Go text templates.

This is a quick proof-of-concept.  Needs tests.  I may not be able to work on this for several days, but I wanted to push it out to see what others think about this approach.

Updates #160 