### PR TITLE
Static parameter warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ See the [webhook-contrib][wc] repository for a collections of tools and helpers 
 
 # Sponsors
 ## <a href="https://www.browserstack.com/?ref=webhook"><img src="http://www.hajdarevic.net/browserstack.svg" alt="BrowserStack" width="250"/></a>
-BrowserStack is a cloud-based cross-browser testing tool that enables developers to test their websites across various browsers on different operating systems and mobile devices, without requiring users to install virtual machines, devices or emulators.
+[BrowserStack](https://www.browserstack.com/?ref=webhook) is a cloud-based cross-browser testing tool that enables developers to test their websites across various browsers on different operating systems and mobile devices, without requiring users to install virtual machines, devices or emulators.
 
 
 # License

--- a/webhook.go
+++ b/webhook.go
@@ -155,11 +155,11 @@ func main() {
 
 	l.SetFormat("{{.Status}} | {{.Duration}} | {{.Hostname}} | {{.Method}} {{.Path}} \n")
 
-        standardLogger := log.New(os.Stdout, "[webhook] ", log.Ldate|log.Ltime)
+	standardLogger := log.New(os.Stdout, "[webhook] ", log.Ldate|log.Ltime)
 
-        if !*verbose {
-                standardLogger.SetOutput(ioutil.Discard)
-        }
+	if !*verbose {
+		standardLogger.SetOutput(ioutil.Discard)
+	}
 
 	l.ALogger = standardLogger
 

--- a/webhook.go
+++ b/webhook.go
@@ -312,7 +312,21 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 func handleHook(h *hook.Hook, headers, query, payload *map[string]interface{}, body *[]byte) (string, error) {
 	var errors []error
 
-	cmd := exec.Command(h.ExecuteCommand)
+	// check the command exists
+	cmdPath, err := exec.LookPath(h.ExecuteCommand)
+	if err != nil {
+		log.Printf("unable to locate command: '%s'", h.ExecuteCommand)
+
+		// check if parameters specified in execute-command by mistake
+		if strings.IndexByte(h.ExecuteCommand, ' ') != -1 {
+			s := strings.Fields(h.ExecuteCommand)[0]
+			log.Printf("use 'pass-arguments-to-command' to specify args for '%s'", s)
+		}
+
+		return "", err
+	}
+
+	cmd := exec.Command(cmdPath)
 	cmd.Dir = h.CommandWorkingDirectory
 
 	cmd.Args, errors = h.ExtractCommandArguments(headers, query, payload)


### PR DESCRIPTION
I have added the logic to produce log warning if static command line parameters are specified in 'execute-command' (issue #151):

`"execute-command": "/bin/echo test"`

will produce:

```
[webhook] 2017/08/25 23:31:55 unable to locate command: '/bin/echo test'
[webhook] 2017/08/25 23:31:55 use 'pass-arguments-to-command' to specify args for '/bin/echo'
```

Let me know if you want me to do it in a different way. 