### PR TITLE
max-concurrency hook property support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ $ go get github.com/adnanh/webhook
 to get the latest version of the [webhook](https://github.com/adnanh/webhook/).
 
 ### Using package manager
-#### Debian "sid"
-If you are using unstable version of Debian linux ("sid"), you can install webhook using `apt-get install webhook` which will install community packaged version (thanks [@freeekanayaka](https://github.com/freeekanayaka)) from https://packages.debian.org/sid/webhook
+#### Debian
+If you are using Debian linux ("stretch" or later), you can install webhook using `apt-get install webhook` which will install community packaged version (thanks [@freeekanayaka](https://github.com/freeekanayaka)) from https://packages.debian.org/sid/webhook
 
 ### Download prebuilt binaries
 Prebuilt binaries for different architectures are available at [GitHub Releases](https://github.com/adnanh/webhook/releases).

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -381,6 +381,7 @@ type Hook struct {
 	PassEnvironmentToCommand            []Argument      `json:"pass-environment-to-command,omitempty"`
 	PassArgumentsToCommand              []Argument      `json:"pass-arguments-to-command,omitempty"`
 	JSONStringParameters                []Argument      `json:"parse-parameters-as-json,omitempty"`
+	MaxConcurrency                      int             `json:"max-concurrency,omiempty"`
 	TriggerRule                         *Rules          `json:"trigger-rule,omitempty"`
 	TriggerRuleMismatchHttpResponseCode int             `json:"trigger-rule-mismatch-http-response-code,omitempty"`
 }


### PR DESCRIPTION
I have implemented support for hook concurrency limits (issue #148):

```
   {
     "id": "sleep",
     "execute-command": "/tmp/sleep-test.bsh",
     "command-working-directory": "/tmp",
     "include-command-output-in-response": true,
     "max-concurrency": 2
   }
```

When the limit is reached, webhook will return `429 Too Many Requests` error and show error message:

```
[webhook] 2017/08/26 11:02:43 sleep got matched
[webhook] 2017/08/26 11:02:43 reached concurrency limit for: sleep (max=2)
[webhook] 2017/08/26 11:02:43 429 | 114.527µs | localhost:9000 | GET /hooks/sleep 
```

Let me know if you want it to be implemented differently.