### PR TITLE
max-concurrency hook property support

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -381,6 +381,7 @@ type Hook struct {
 	PassEnvironmentToCommand            []Argument      `json:"pass-environment-to-command,omitempty"`
 	PassArgumentsToCommand              []Argument      `json:"pass-arguments-to-command,omitempty"`
 	JSONStringParameters                []Argument      `json:"parse-parameters-as-json,omitempty"`
+	MaxConcurrency                      int             `json:"max-concurrency,omiempty"`
 	TriggerRule                         *Rules          `json:"trigger-rule,omitempty"`
 	TriggerRuleMismatchHttpResponseCode int             `json:"trigger-rule-mismatch-http-response-code,omitempty"`
 }


### PR DESCRIPTION
I have implemented support for hook concurrency limits (issue #148):

```
   {
     "id": "sleep",
     "execute-command": "/tmp/sleep-test.bsh",
     "command-working-directory": "/tmp",
     "include-command-output-in-response": true,
     "max-concurrency": 2
   }
```

When the limit is reached, webhook will return `429 Too Many Requests` error and show error message:

```
[webhook] 2017/08/26 11:02:43 sleep got matched
[webhook] 2017/08/26 11:02:43 reached concurrency limit for: sleep (max=2)
[webhook] 2017/08/26 11:02:43 429 | 114.527µs | localhost:9000 | GET /hooks/sleep 
```

Let me know if you want it to be implemented differently.