### PR TITLE
Catch error for commands with output capture = false

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -277,18 +277,17 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set(responseHeader.Name, responseHeader.Value)
 			}
 
-			if matchedHook.CaptureCommandOutput {
-				response, err := handleHook(matchedHook, rid, &headers, &query, &payload, &body)
+			response, err := handleHook(matchedHook, rid, &headers, &query, &payload, &body)
+			if err != nil {
+				w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprintf(w, "Error occurred while executing the hook's command. Please check your logs for more details.")
+				return
+			}
 
-				if err != nil {
-					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-					w.WriteHeader(http.StatusInternalServerError)
-					fmt.Fprintf(w, "Error occurred while executing the hook's command. Please check your logs for more details.")
-				} else {
-					fmt.Fprintf(w, response)
-				}
+			if matchedHook.CaptureCommandOutput {
+				fmt.Fprintf(w, response)
 			} else {
-				go handleHook(matchedHook, rid, &headers, &query, &payload, &body)
 				fmt.Fprintf(w, matchedHook.ResponseMessage)
 			}
 			return


### PR DESCRIPTION
This is a proposed fix for inconsistency in handling exit status of command with `include-command-output-in-response` set to `true` and `false`.

Currently, if `include-command-output-in-response: true` and command exits with error code != 0, `webhook` will return error code `500`. However, when set to `false`, `webhook` ignores errors and always returns code `200`.

Moreover, there are two different paths in the code for each case, which seems as additional inconsistency.

This PR ensures command is spawned in a consistent manner and returns code `500` if command fails in both output capturing and non-capturing modes. There is no need to spawn a separate goroutine, because handler is spawned as a goroutine when the request comes in. This PR executes command in the same goroutine as the handler.

It also fixes issues we have discussed in PR #167:
- rate limit now works in both output capturing and non-capturing modes.
- removes the issue with handling channels due to additional being spawned.
- writing to non-existant channel is not possible as no additional goroutine.

Let me know if this solution works.
