### PR TITLE
PoC: Add PROXY protocol support

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,0 +1,30 @@
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// tcpKeepAliveListener copied from Go net/http package.
+
+package main
+
+import (
+	"net"
+	"time"
+)
+
+// tcpKeepAliveListener sets TCP keep-alive timeouts on accepted
+// connections. It's used by ListenAndServe and ListenAndServeTLS so
+// dead TCP connections (e.g. closing laptop mid-download) eventually
+// go away.
+type tcpKeepAliveListener struct {
+	*net.TCPListener
+}
+
+func (ln tcpKeepAliveListener) Accept() (c net.Conn, err error) {
+	tc, err := ln.AcceptTCP()
+	if err != nil {
+		return
+	}
+	tc.SetKeepAlive(true)
+	tc.SetKeepAlivePeriod(3 * time.Minute)
+	return tc, nil
+}


### PR DESCRIPTION
This commit adds a custom net.Listener to the webhook HTTP server to
enable PROXY protocol support.  I've copied in the keep-alive listener
from the Go net/http package, so the non-PROXY server should behave just
like the stdlib.

### Proof of Concept

This PR is a proof of concept at the moment.  I haven't tested `webhook` behind a PROXY-enabled proxy.  The go-proxyproto package looked simple enough and does all the heavy lifting, so I thought I'd just take a stab at an implementation. Interested parties need to help test it out (@stephenreay).

*TODO:*
- [x] Actually test it behind a PROXY-enabled proxy
- [ ] Update docs
- [ ] Vendor dependencies
- [ ] Tests
- [ ] Add IP whitelisting option

Fixes #152 