### PR TITLE
Add support for Scalr webhook signature verification (new Match Rule) #200 - Updated

### DIFF
--- a/hook/hook_test.go
+++ b/hook/hook_test.go
@@ -60,6 +60,54 @@ func TestCheckPayloadSignature256(t *testing.T) {
 	}
 }
 
+var checkScalrSignatureTests = []struct {
+	description       string
+	headers           map[string]interface{}
+	payload           []byte
+	secret            string
+	expectedSignature string
+	ok                bool
+}{
+	{
+		"Valid signature",
+		map[string]interface{}{"Date": "Thu 07 Sep 2017 06:30:04 UTC", "X-Signature": "48e395e38ac48988929167df531eb2da00063a7d"},
+		[]byte(`{"a": "b"}`), "bilFGi4ZVZUdG+C6r0NIM9tuRq6PaG33R3eBUVhLwMAErGBaazvXe4Gq2DcJs5q+",
+		"48e395e38ac48988929167df531eb2da00063a7d", true,
+	},
+	{
+		"Wrong signature",
+		map[string]interface{}{"Date": "Thu 07 Sep 2017 06:30:04 UTC", "X-Signature": "999395e38ac48988929167df531eb2da00063a7d"},
+		[]byte(`{"a": "b"}`), "bilFGi4ZVZUdG+C6r0NIM9tuRq6PaG33R3eBUVhLwMAErGBaazvXe4Gq2DcJs5q+",
+		"48e395e38ac48988929167df531eb2da00063a7d", false,
+	},
+	{
+		"Missing Date header",
+		map[string]interface{}{"X-Signature": "999395e38ac48988929167df531eb2da00063a7d"},
+		[]byte(`{"a": "b"}`), "bilFGi4ZVZUdG+C6r0NIM9tuRq6PaG33R3eBUVhLwMAErGBaazvXe4Gq2DcJs5q+",
+		"48e395e38ac48988929167df531eb2da00063a7d", false,
+	},
+	{
+		"Missing X-Signature header",
+		map[string]interface{}{"Date": "Thu 07 Sep 2017 06:30:04 UTC"},
+		[]byte(`{"a": "b"}`), "bilFGi4ZVZUdG+C6r0NIM9tuRq6PaG33R3eBUVhLwMAErGBaazvXe4Gq2DcJs5q+",
+		"48e395e38ac48988929167df531eb2da00063a7d", false,
+	},
+}
+
+func TestCheckScalrSignature(t *testing.T) {
+	for _, testCase := range checkScalrSignatureTests {
+		valid, err := CheckScalrSignature(testCase.headers, testCase.payload, testCase.secret, false)
+		if valid != testCase.ok {
+			t.Errorf("failed to check scalr signature fot test case: %s\nexpected ok:%#v, got ok:%#v}",
+				testCase.description, testCase.ok, valid)
+		}
+
+		if err != nil && strings.Contains(err.Error(), testCase.expectedSignature) {
+			t.Errorf("error message should not disclose expected mac: %s on test case %s", err, testCase.description)
+		}
+	}
+}
+
 var extractParameterTests = []struct {
 	s      string
 	params interface{}


### PR DESCRIPTION
NEW/UPDATED pull requested to resolve bad commit naming (as spotted by @moorereason . This replaces original pull request 209

This pull request is to import into the upstream release the updates @AloysAugustin performed on folk scalr-tutorials/webhook to support scalr signing key with Adnanh/webhook. I've done a very basic copy across and testing. All seems good...

**NOTE:** Scalr (scalr.com) is a Cloud Management Platform hat companies use and this is support leveraging scalr Webhook posts with additional security.

Add a new match rule type that checks for a Scalr webhook signature. Tracking ticket #200

Based off feedback I will then do a PR for documentation/example updates

**The signature algorithm is described here:**
https://scalr-wiki.atlassian.net/wiki/spaces/docs/pages/6193247/Webhook+Security+and+Authentication

**An example match rule ifor a Scalr webhook will look like:**

"match": {
"type": "scalr-signature",
"secret": ""
}

Adds Scalr webhook signature verification to verify the Scalr signature on a hook, using a match rule similar to this example:

[
{
"id": "scalr-test",
"execute-command": "test.sh",
"trigger-rule": {
"match": {
"type": "scalr-signature",
"secret": "Scalr-provided signing key"
}
}
}
]

Note that the trigger rule checks the scalr signature and checks that the request was signed less than 5 minutes before it was received. Please make sure that NTP is enabled on both your Scalr Server and the webhook handler to prevent any issues.