### PR TITLE
Update to Scalr Signature miss-match response

### DIFF
--- a/hook/hook.go
+++ b/hook/hook.go
@@ -146,8 +146,8 @@ func CheckScalrSignature(headers map[string]interface{}, body []byte, signingKey
  	expectedSignature := hex.EncodeToString(mac.Sum(nil))
  
  	if !hmac.Equal([]byte(providedSignature), []byte(expectedSignature)) {
- 		return false, &SignatureError{providedSignature}
- 	}
+ 		return false, nil
+	}
 
 	if !checkDate {
 		return true, nil


### PR DESCRIPTION
Update to Scalr Signature miss-match response from ERROR to NIL. This is to resolve the issue with AND or OR Match rules (Issue #234)