### PR TITLE
Added HttpResponseCode hook setting

### DIFF
--- a/docs/Hook-Definition.md
+++ b/docs/Hook-Definition.md
@@ -8,6 +8,7 @@ Hooks are defined as JSON objects. Please note that in order to be considered va
  * `command-working-directory` - specifies the working directory that will be used for the script when it's executed
  * `response-message` - specifies the string that will be returned to the hook initiator
  * `response-headers` - specifies the list of headers in format `{"name": "X-Example-Header", "value": "it works"}` that will be returned in HTTP response for the hook
+ * `http-response-code` - specifies the HTTP status code to be returned
  * `include-command-output-in-response` - boolean whether webhook should wait for the command to finish and return the raw output as a response to the hook initiator. If the command fails to execute or encounters any errors while executing the response will result in 500 Internal Server Error HTTP status code, otherwise the 200 OK status code will be returned.
  * `include-command-output-in-response-on-error` - boolean whether webhook should include command stdout & stderror as a response in failed executions. It only works if `include-command-output-in-response` is set to `true`.
  * `parse-parameters-as-json` - specifies the list of arguments that contain JSON strings. These parameters will be decoded by webhook and you can access them like regular objects in rules and `pass-arguments-to-command`.

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -391,6 +391,7 @@ type Hook struct {
 	JSONStringParameters                []Argument      `json:"parse-parameters-as-json,omitempty"`
 	TriggerRule                         *Rules          `json:"trigger-rule,omitempty"`
 	TriggerRuleMismatchHttpResponseCode int             `json:"trigger-rule-mismatch-http-response-code,omitempty"`
+	HttpResponseCode                    int             `json:"http-response-code,omitempty"`
 }
 
 // ParseJSONParameters decodes specified arguments to JSON objects and replaces the


### PR DESCRIPTION
Adds an `http-response-code` hook setting, used instead of default 200.

I use webhook to process form submissions from my website. With this feature I'm able to do a proper 302 redirect to a "Thanks for your submission" page after the form has been submitted.

I tested the functionality in Firefox and Chrome.