### PR TITLE
Added SuccessHttpResponseCode hook setting

### DIFF
--- a/docs/Hook-Definition.md
+++ b/docs/Hook-Definition.md
@@ -8,6 +8,7 @@ Hooks are defined as JSON objects. Please note that in order to be considered va
  * `command-working-directory` - specifies the working directory that will be used for the script when it's executed
  * `response-message` - specifies the string that will be returned to the hook initiator
  * `response-headers` - specifies the list of headers in format `{"name": "X-Example-Header", "value": "it works"}` that will be returned in HTTP response for the hook
+ * `http-response-code` - specifies the HTTP status code to be returned
  * `include-command-output-in-response` - boolean whether webhook should wait for the command to finish and return the raw output as a response to the hook initiator. If the command fails to execute or encounters any errors while executing the response will result in 500 Internal Server Error HTTP status code, otherwise the 200 OK status code will be returned.
  * `include-command-output-in-response-on-error` - boolean whether webhook should include command stdout & stderror as a response in failed executions. It only works if `include-command-output-in-response` is set to `true`.
  * `parse-parameters-as-json` - specifies the list of arguments that contain JSON strings. These parameters will be decoded by webhook and you can access them like regular objects in rules and `pass-arguments-to-command`.

--- a/docs/Hook-Definition.md
+++ b/docs/Hook-Definition.md
@@ -8,7 +8,7 @@ Hooks are defined as JSON objects. Please note that in order to be considered va
  * `command-working-directory` - specifies the working directory that will be used for the script when it's executed
  * `response-message` - specifies the string that will be returned to the hook initiator
  * `response-headers` - specifies the list of headers in format `{"name": "X-Example-Header", "value": "it works"}` that will be returned in HTTP response for the hook
- * `http-response-code` - specifies the HTTP status code to be returned
+ * `success-http-response-code` - specifies the HTTP status code to be returned upon success
  * `include-command-output-in-response` - boolean whether webhook should wait for the command to finish and return the raw output as a response to the hook initiator. If the command fails to execute or encounters any errors while executing the response will result in 500 Internal Server Error HTTP status code, otherwise the 200 OK status code will be returned.
  * `include-command-output-in-response-on-error` - boolean whether webhook should include command stdout & stderror as a response in failed executions. It only works if `include-command-output-in-response` is set to `true`.
  * `parse-parameters-as-json` - specifies the list of arguments that contain JSON strings. These parameters will be decoded by webhook and you can access them like regular objects in rules and `pass-arguments-to-command`.

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -427,7 +427,7 @@ type Hook struct {
 	TriggerRule                         *Rules          `json:"trigger-rule,omitempty"`
 	TriggerRuleMismatchHttpResponseCode int             `json:"trigger-rule-mismatch-http-response-code,omitempty"`
 	IncomingPayloadContentType          string          `json:"incoming-payload-content-type,omitempty"`	
-	HttpResponseCode                    int             `json:"http-response-code,omitempty"`
+	SuccessHttpResponseCode             int             `json:"success-http-response-code,omitempty"`
 }
 
 // ParseJSONParameters decodes specified arguments to JSON objects and replaces the

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -427,6 +427,7 @@ type Hook struct {
 	TriggerRule                         *Rules          `json:"trigger-rule,omitempty"`
 	TriggerRuleMismatchHttpResponseCode int             `json:"trigger-rule-mismatch-http-response-code,omitempty"`
 	IncomingPayloadContentType          string          `json:"incoming-payload-content-type,omitempty"`	
+	HttpResponseCode                    int             `json:"http-response-code,omitempty"`
 }
 
 // ParseJSONParameters decodes specified arguments to JSON objects and replaces the

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -426,7 +426,7 @@ type Hook struct {
 	JSONStringParameters                []Argument      `json:"parse-parameters-as-json,omitempty"`
 	TriggerRule                         *Rules          `json:"trigger-rule,omitempty"`
 	TriggerRuleMismatchHttpResponseCode int             `json:"trigger-rule-mismatch-http-response-code,omitempty"`
-	IncomingPayloadContentType          string          `json:"incoming-payload-content-type,omitempty"`	
+	IncomingPayloadContentType          string          `json:"incoming-payload-content-type,omitempty"`
 	SuccessHttpResponseCode             int             `json:"success-http-response-code,omitempty"`
 }
 

--- a/webhook.go
+++ b/webhook.go
@@ -299,8 +299,8 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 				go handleHook(matchedHook, rid, &headers, &query, &payload, &body)
 
 				// Check if a return code is configured for the hook
-				if matchedHook.HttpResponseCode != 0 {
-					writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.HttpResponseCode)
+				if matchedHook.SuccessHttpResponseCode != 0 {
+					writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.SuccessHttpResponseCode)
 				}
 
 				fmt.Fprintf(w, matchedHook.ResponseMessage)

--- a/webhook.go
+++ b/webhook.go
@@ -293,12 +293,16 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 						fmt.Fprintf(w, "Error occurred while executing the hook's command. Please check your logs for more details.")
 					}
 				} else {
+					// Check if a success return code is configured for the hook
+					if matchedHook.SuccessHttpResponseCode != 0 {
+						writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.HttpResponseCode)
+					}
 					fmt.Fprintf(w, response)
 				}
 			} else {
 				go handleHook(matchedHook, rid, &headers, &query, &payload, &body)
 
-				// Check if a return code is configured for the hook
+				// Check if a success return code is configured for the hook
 				if matchedHook.SuccessHttpResponseCode != 0 {
 					writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.SuccessHttpResponseCode)
 				}

--- a/webhook.go
+++ b/webhook.go
@@ -297,6 +297,12 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 				}
 			} else {
 				go handleHook(matchedHook, rid, &headers, &query, &payload, &body)
+
+				// Check if a return code is configured for the hook
+				if matchedHook.HttpResponseCode != 0 {
+					writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.HttpResponseCode)
+				}
+
 				fmt.Fprintf(w, matchedHook.ResponseMessage)
 			}
 			return
@@ -304,13 +310,7 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 
 		// Check if a return code is configured for the hook
 		if matchedHook.TriggerRuleMismatchHttpResponseCode != 0 {
-			// Check if the configured return code is supported by the http package
-			// by testing if there is a StatusText for this code.
-			if len(http.StatusText(matchedHook.TriggerRuleMismatchHttpResponseCode)) > 0 {
-				w.WriteHeader(matchedHook.TriggerRuleMismatchHttpResponseCode)
-			} else {
-				log.Printf("[%s] %s got matched, but the configured return code %d is unknown - defaulting to 200\n", rid, matchedHook.ID, matchedHook.TriggerRuleMismatchHttpResponseCode)
-			}
+			writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.TriggerRuleMismatchHttpResponseCode)
 		}
 
 		// if none of the hooks got triggered
@@ -406,6 +406,16 @@ func handleHook(h *hook.Hook, rid string, headers, query, payload *map[string]in
 	log.Printf("[%s] finished handling %s\n", rid, h.ID)
 
 	return string(out), err
+}
+
+func writeHttpResponseCode(w http.ResponseWriter, rid string, hookId string, responseCode int) {
+	// Check if the given return code is supported by the http package
+	// by testing if there is a StatusText for this code.
+	if len(http.StatusText(responseCode)) > 0 {
+		w.WriteHeader(responseCode)
+	} else {
+		log.Printf("[%s] %s got matched, but the configured return code %d is unknown - defaulting to 200\n", rid, hookId, responseCode)
+	}
 }
 
 func reloadHooks(hooksFilePath string) {

--- a/webhook.go
+++ b/webhook.go
@@ -295,7 +295,7 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 				} else {
 					// Check if a success return code is configured for the hook
 					if matchedHook.SuccessHttpResponseCode != 0 {
-						writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.HttpResponseCode)
+						writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.SuccessHttpResponseCode)
 					}
 					fmt.Fprintf(w, response)
 				}


### PR DESCRIPTION
Revamp of PR https://github.com/adnanh/webhook/pull/259

Issue 1, 2 and 3 should have been taken care of.

I'm struggling with item 4 though. First time writing go, and I'm a bit lost. I suspect I should modify `webhook_test.go` and do something very similar to

	// test with custom return code
	{"empty payload", "github", nil, `{}`, false, http.StatusBadRequest, `Hook rules were not satisfied.`, ``},
	// test with custom invalid http code, should default to 200 OK
	{"empty payload", "bitbucket", nil, `{}`, false, http.StatusOK, `Hook rules were not satisfied.`, ``},

@adnanh would you mind filling in the blanks here? (I'd be happy to read your patch and learn how to do it myslef for the next patch!) Or alternatively, explaining the details, including how to run tests locally, and I should be able to wrap it up.