### PR TITLE
Fix broken API usage for current version of go.uuid

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -202,7 +202,7 @@ func main() {
 func hookHandler(w http.ResponseWriter, r *http.Request) {
 
 	// generate a request id for logging
-	rid := uuid.NewV4().String()[:6]
+	rid := uuid.Must(uuid.NewV4()).String()[:6]
 
 	log.Printf("[%s] incoming HTTP request from %s\n", rid, r.RemoteAddr)
 


### PR DESCRIPTION
This pull request fixes the newly introduced way of using go.uuid. See also https://github.com/satori/go.uuid/issues/66