### PR TITLE
Update error checking of uuid generate

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -202,7 +202,13 @@ func main() {
 func hookHandler(w http.ResponseWriter, r *http.Request) {
 
 	// generate a request id for logging
-	rid := uuid.NewV4().String()[:6]
+	uuid, err := uuid.NewV4()
+
+	if err != nil {
+		log.Printf("[%s] error generating uuid %s\n", uuid, err)
+	}
+
+	rid := uuid.String()[:6]
 
 	log.Printf("[%s] incoming HTTP request from %s\n", rid, r.RemoteAddr)
 


### PR DESCRIPTION
Found an error while attempting to build. UUID returns UUID, error

```
type Generator interface {
...
	NewV4() (UUID, error)
```