### PR TITLE
Fix issue with relative paths and command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ $ go get github.com/adnanh/webhook
 to get the latest version of the [webhook][w].
 
 ### Using package manager
+#### Snap store
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-white.svg)](https://snapcraft.io/webhook)
+
 #### Ubuntu
 If you are using Ubuntu linux (17.04 or later), you can install webhook using `sudo apt-get install webhook` which will install community packaged version.
 

--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -377,3 +377,50 @@ In order to leverage the Signing Key for addtional authentication/security you m
 ]
 
 ```
+
+## Travis CI webhook
+Travis sends webhooks as `payload=<JSON_STRING>`, so the payload needs to be parsed as JSON. Here is an example to run on successful builds of the master branch.
+
+```json
+[
+  {
+    "id": "deploy",
+    "execute-command": "/root/my-server/deployment.sh",
+    "command-working-directory": "/root/my-server",
+    "parse-parameters-as-json": [
+      {
+        "source": "payload",
+        "name": "payload"
+      }
+    ],
+    "trigger-rule":
+    {
+      "and":
+      [
+        {
+          "match":
+          {
+            "type": "value",
+            "value": "passed",
+            "parameter": {
+              "name": "payload.state",
+              "source": "payload"
+            }
+          }
+        },
+        {
+          "match":
+          {
+            "type": "value",
+            "value": "master",
+            "parameter": {
+              "name": "payload.branch",
+              "source": "payload"
+            }
+          }
+        }
+      ]
+    }
+  }
+]
+```

--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -176,6 +176,61 @@ Values in the request body can be accessed in the command or to the match rule b
   }
 ]
 ```
+## Incoming Gitea webhook
+```json
+[
+  {
+    "id": "webhook",
+    "execute-command": "/home/adnan/redeploy-go-webhook.sh",
+    "command-working-directory": "/home/adnan/go",
+    "pass-arguments-to-command":
+    [
+      {
+        "source": "payload",
+        "name": "head_commit.id"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.name"
+      },
+      {
+        "source": "payload",
+        "name": "pusher.email"
+      }
+    ],
+    "trigger-rule":
+    {
+      "and":
+      [
+        {
+          "match":
+          {
+            "type": "value",
+            "value": "mysecret",
+            "parameter":
+            {
+              "source": "payload",
+              "name": "secret"
+            }
+          }
+        },
+        {
+          "match":
+          {
+            "type": "value",
+            "value": "refs/heads/master",
+            "parameter":
+            {
+              "source": "payload",
+              "name": "ref"
+            }
+          }
+        }
+      ]
+    }
+  }
+]
+```
 
 ## Slack slash command
 ```json

--- a/webhook.go
+++ b/webhook.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -328,6 +329,13 @@ func handleHook(h *hook.Hook, rid string, headers, query, payload *map[string]in
 
 	// check the command exists
 	cmdPath, err := exec.LookPath(h.ExecuteCommand)
+	if err != nil {
+        // give a last chance, maybe is a relative path
+        relativeToCwd := filepath.Join(h.CommandWorkingDirectory, h.ExecuteCommand)
+		// check the command exists
+		cmdPath, err = exec.LookPath(relativeToCwd)
+	}
+
 	if err != nil {
 		log.Printf("unable to locate command: '%s'", h.ExecuteCommand)
 


### PR DESCRIPTION
Now webhook can execute hooks relatively to the working directory. Fix issue #316.

I am new to go so if something is not good looking please let me know how I might improve it.