### PR TITLE
Multiple Signature Support

### DIFF
--- a/docs/Hook-Rules.md
+++ b/docs/Hook-Rules.md
@@ -186,6 +186,13 @@ For the regex syntax, check out <http://golang.org/pkg/regexp/syntax/>
 }
 ```
 
+Note that if multiple signatures were passed via a comma separated string, each
+will be tried unless a match is found. For example:
+
+```
+X-Hub-Signature: sha1=the-first-signature,sha1=the-second-signature
+```
+
 ### 4. Match payload-hash-sha256
 ```json
 {
@@ -202,6 +209,13 @@ For the regex syntax, check out <http://golang.org/pkg/regexp/syntax/>
 }
 ```
 
+Note that if multiple signatures were passed via a comma separated string, each
+will be tried unless a match is found. For example:
+
+```
+X-Hub-Signature: sha256=the-first-signature,sha256=the-second-signature
+```
+
 ### 5. Match payload-hash-sha512
 ```json
 {
@@ -216,6 +230,13 @@ For the regex syntax, check out <http://golang.org/pkg/regexp/syntax/>
     }
   }
 }
+```
+
+Note that if multiple signatures were passed via a comma separated string, each
+will be tried unless a match is found. For example:
+
+```
+X-Hub-Signature: sha512=the-first-signature,sha512=the-second-signature
 ```
 
 ### 6. Match Whitelisted IP range

--- a/hook/hook.go
+++ b/hook/hook.go
@@ -100,8 +100,8 @@ func (e *ParseError) Error() string {
 	return e.Err.Error()
 }
 
-// ExtractCommaSeperatedValues will extract the values matching the key.
-func ExtractCommaSeperatedValues(source, prefix string) []string {
+// ExtractCommaSeparatedValues will extract the values matching the key.
+func ExtractCommaSeparatedValues(source, prefix string) []string {
 	parts := strings.Split(source, ",")
 	values := make([]string, 0)
 	for _, part := range parts {
@@ -117,7 +117,7 @@ func ExtractSignatures(signature, prefix string) []string {
 	// If there are multiple possible matches, let the comma seperated extractor
 	// do it's work.
 	if strings.Contains(signature, ",") {
-		return ExtractCommaSeperatedValues(signature, prefix)
+		return ExtractCommaSeparatedValues(signature, prefix)
 	}
 
 	// There were no commas, so just trim the prefix (if it even exists) and

--- a/hook/hook_test.go
+++ b/hook/hook_test.go
@@ -48,8 +48,11 @@ var checkPayloadSignatureTests = []struct {
 }{
 	{[]byte(`{"a": "z"}`), "secret", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", true},
 	{[]byte(`{"a": "z"}`), "secret", "sha1=b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", true},
+	{[]byte(`{"a": "z"}`), "secret", "sha1=XXXe04cbb22afa8ffbff8796fc1894ed27badd9e,sha1=b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", true},
 	// failures
 	{[]byte(`{"a": "z"}`), "secret", "XXXe04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", false},
+	{[]byte(`{"a": "z"}`), "secret", "sha1=XXXe04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", false},
+	{[]byte(`{"a": "z"}`), "secret", "sha1=XXXe04cbb22afa8ffbff8796fc1894ed27badd9e,sha1=XXXe04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", false},
 	{[]byte(`{"a": "z"}`), "secreX", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "900225703e9342328db7307692736e2f7cc7b36e", false},
 	{[]byte(`{"a": "z"}`), "", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "", false},
 }
@@ -76,8 +79,11 @@ var checkPayloadSignature256Tests = []struct {
 }{
 	{[]byte(`{"a": "z"}`), "secret", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", true},
 	{[]byte(`{"a": "z"}`), "secret", "sha256=f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", true},
+	{[]byte(`{"a": "z"}`), "secret", "sha256=XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89,sha256=f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", true},
 	// failures
 	{[]byte(`{"a": "z"}`), "secret", "XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", false},
+	{[]byte(`{"a": "z"}`), "secret", "sha256=XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", false},
+	{[]byte(`{"a": "z"}`), "secret", "sha256=XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89,sha256=XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", false},
 	{[]byte(`{"a": "z"}`), "", "XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "", false},
 }
 


### PR DESCRIPTION
The current implementation of the `payload-hash-sha256` and `payload-hash-sha1` match types only considers secrets provided one per header. To support secret rolling (as used by Stripe), I propose supporting the following scheme:

Initially, we have the following:

```
X-Coral-Signature: sha256=9ebcba58721f138c3f82a5896f350601aa5b162f5e274b47a312118bbc9ba9f0
```

But when we're rolling secrets, we send requests with a signature from the old secret, and the new secret for a time frame allowing administrators to update code or environment variables to the new secret. This gives us a header that looks like this instead:

```
X-Coral-Signature: sha256=3ad8d2e511faefce65e6576f5ea850431ca2e1f39d8b3b13e3dce6971d35f1eb,sha256=9ebcba58721f138c3f82a5896f350601aa5b162f5e274b47a312118bbc9ba9f0
```

Which is essentially:

```
sha256={ new signature },sha256={ old signature }
```

This is the same process for the `sha1` type.