### PR TITLE
Fix invalid assumption that multipart forms can be parsed in te same way as urlencoded forms.

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -341,8 +341,8 @@ func handleHook(h *hook.Hook, rid string, headers, query, payload *map[string]in
 	// check the command exists
 	cmdPath, err := exec.LookPath(h.ExecuteCommand)
 	if err != nil {
-        // give a last chance, maybe is a relative path
-        relativeToCwd := filepath.Join(h.CommandWorkingDirectory, h.ExecuteCommand)
+		// give a last chance, maybe is a relative path
+		relativeToCwd := filepath.Join(h.CommandWorkingDirectory, h.ExecuteCommand)
 		// check the command exists
 		cmdPath, err = exec.LookPath(relativeToCwd)
 	}

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -617,6 +617,7 @@ env: HOOK_head_commit.timestamp=2013-03-12T08:14:29-07:00
 	// Check logs
 	{"static params should pass", "static-params-ok", nil, `{}`, false, http.StatusOK, "arg: passed\n", `(?s)command output: arg: passed`},
 	{"command with space logs warning", "warn-on-space", nil, `{}`, false, http.StatusInternalServerError, "Error occurred while executing the hook's command. Please check your logs for more details.", `(?s)unable to locate command.*use 'pass[-]arguments[-]to[-]command' to specify args`},
+	{"unsupported content type error", "github", map[string]string{"Content-Type": "nonexistent/format"}, `{}`, false, http.StatusBadRequest, `Hook rules were not satisfied.`, `(?s)error parsing body payload due to unsupported content type header:`},
 }
 
 // buffer provides a concurrency-safe bytes.Buffer to tests above.


### PR DESCRIPTION
Refactored code to use switch-case statement over the `Content-Type` header and log unsupported content types instead of silently failing.

Also made the `x-www-form-urlencoded` content type handler more specific (as opposed to the previous code which looked for `form` occurence in the value),
as we need to use different logic for multipart forms, which we'll hopefully implement soon.