### PR TITLE
Add setuid and setgid options for dropping privileges

### DIFF
--- a/docs/Webhook-Parameters.md
+++ b/docs/Webhook-Parameters.md
@@ -25,6 +25,10 @@ Usage of webhook:
         port the webhook should serve hooks on (default 9000)
   -secure
         use HTTPS instead of HTTP
+  -setgid int
+        set group ID after opening listening port; must be used with setuid
+  -setuid int
+        set user ID after opening listening port; must be used with setgid
   -template
         parse hooks file as a Go template
   -tls-min-version string

--- a/droppriv_nope.go
+++ b/droppriv_nope.go
@@ -1,0 +1,12 @@
+// +build linux windows
+
+package main
+
+import (
+	"errors"
+	"runtime"
+)
+
+func dropPrivileges(uid, gid int) error {
+	return errors.New("setuid and setgid not supported on " + runtime.GOOS)
+}

--- a/droppriv_unix.go
+++ b/droppriv_unix.go
@@ -1,0 +1,21 @@
+// +build !windows,!linux
+
+package main
+
+import (
+	"syscall"
+)
+
+func dropPrivileges(uid, gid int) error {
+	err := syscall.Setgid(gid)
+	if err != nil {
+		return err
+	}
+
+	err = syscall.Setuid(uid)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}


### PR DESCRIPTION
This ended up being fairly straight-forward.  Tested on FreeBSD 12.1.  Should work on most BSDs and macOS.

One additional change I worked in here is to not call `log.Fatal` after a `defer`. It's bad practice, so I changed those to `log.Print`+`return`.

Fixes #198 