### PR TITLE
Feature/http methods

### DIFF
--- a/docs/Hook-Definition.md
+++ b/docs/Hook-Definition.md
@@ -10,6 +10,7 @@ Hooks are defined as JSON objects. Please note that in order to be considered va
  * `response-headers` - specifies the list of headers in format `{"name": "X-Example-Header", "value": "it works"}` that will be returned in HTTP response for the hook
  * `success-http-response-code` - specifies the HTTP status code to be returned upon success
  * `incoming-payload-content-type` - sets the `Content-Type` of the incoming HTTP request (ie. `application/json`); useful when the request lacks a `Content-Type` or sends an erroneous value
+ * `http-methods` - a list of allowed HTTP methods, such as `POST` and `GET`
  * `include-command-output-in-response` - boolean whether webhook should wait for the command to finish and return the raw output as a response to the hook initiator. If the command fails to execute or encounters any errors while executing the response will result in 500 Internal Server Error HTTP status code, otherwise the 200 OK status code will be returned.
  * `include-command-output-in-response-on-error` - boolean whether webhook should include command stdout & stderror as a response in failed executions. It only works if `include-command-output-in-response` is set to `true`.
  * `parse-parameters-as-json` - specifies the list of arguments that contain JSON strings. These parameters will be decoded by webhook and you can access them like regular objects in rules and `pass-arguments-to-command`.

--- a/docs/Webhook-Parameters.md
+++ b/docs/Webhook-Parameters.md
@@ -13,6 +13,8 @@ Usage of webhook:
         path to the json file containing defined hooks the webhook should serve, use multiple times to load from different files
   -hotreload
         watch hooks file for changes and reload them automatically
+  -http-methods string
+        globally restrict allowed HTTP methods; separate methods with comma
   -ip string
         ip the webhook should serve hooks on (default "0.0.0.0")
   -key string

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -649,8 +649,7 @@ func (h *Hooks) LoadFromFile(path string, asTemplate bool) error {
 		file = buf.Bytes()
 	}
 
-	e = yaml.Unmarshal(file, h)
-	return e
+	return yaml.Unmarshal(file, h)
 }
 
 // Append appends hooks unless the new hooks contain a hook with an ID that already exists

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -460,6 +460,7 @@ type Hook struct {
 	TriggerRuleMismatchHttpResponseCode int             `json:"trigger-rule-mismatch-http-response-code,omitempty"`
 	IncomingPayloadContentType          string          `json:"incoming-payload-content-type,omitempty"`
 	SuccessHttpResponseCode             int             `json:"success-http-response-code,omitempty"`
+	HTTPMethods                         []string        `json:"http-methods"`
 }
 
 // ParseJSONParameters decodes specified arguments to JSON objects and replaces the

--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -3,6 +3,7 @@
     "id": "github",
     "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",
+    "http-methods": ["POST"],
     "include-command-output-in-response": true,
     "trigger-rule-mismatch-http-response-code": 400,
     "pass-environment-to-command":

--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -3,7 +3,7 @@
     "id": "github",
     "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",
-    "http-methods": ["POST"],
+    "http-methods": ["Post "],
     "include-command-output-in-response": true,
     "trigger-rule-mismatch-http-response-code": 400,
     "pass-environment-to-command":

--- a/test/hooks.yaml.tmpl
+++ b/test/hooks.yaml.tmpl
@@ -1,6 +1,6 @@
 - id: github
   http-methods:
-  - POST
+  - "Post "
   trigger-rule:
     and:
     - match:

--- a/test/hooks.yaml.tmpl
+++ b/test/hooks.yaml.tmpl
@@ -1,4 +1,6 @@
 - id: github
+  http-methods:
+  - POST
   trigger-rule:
     and:
     - match:

--- a/webhook.go
+++ b/webhook.go
@@ -293,7 +293,7 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 
 	if !allowedMethod {
 		w.WriteHeader(http.StatusMethodNotAllowed)
-		log.Printf("[%s] HTTP %s method not implemented for hook %q", rid, r.Method, id)
+		log.Printf("[%s] HTTP %s method not allowed for hook %q", rid, r.Method, id)
 
 		return
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -50,6 +50,7 @@ var (
 	maxMultipartMem    = flag.Int64("max-multipart-mem", 1<<20, "maximum memory in bytes for parsing multipart form data before disk caching")
 	setGID             = flag.Int("setgid", 0, "set group ID after opening listening port; must be used with setuid")
 	setUID             = flag.Int("setuid", 0, "set user ID after opening listening port; must be used with setgid")
+	httpMethods        = flag.String("http-methods", "", "globally restrict allowed HTTP methods; separate methods with comma")
 
 	responseHeaders hook.ResponseHeaders
 	hooksFiles      hook.HooksFiles
@@ -203,7 +204,12 @@ func main() {
 		fmt.Fprint(w, "OK")
 	})
 
-	r.HandleFunc(hooksURL, hookHandler)
+	if *httpMethods == "" {
+		r.HandleFunc(hooksURL, hookHandler)
+	} else {
+		allowed := strings.Split(*httpMethods, ",")
+		r.HandleFunc(hooksURL, hookHandler).Methods(allowed...)
+	}
 
 	addr := fmt.Sprintf("%s:%d", *ip, *port)
 

--- a/webhook.go
+++ b/webhook.go
@@ -253,218 +253,236 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 
 	log.Printf("[%s] incoming HTTP request from %s\n", rid, r.RemoteAddr)
 
+	id := mux.Vars(r)["id"]
+
+	matchedHook := matchLoadedHook(id)
+	if matchedHook == nil {
+		w.WriteHeader(http.StatusNotFound)
+		fmt.Fprint(w, "Hook not found.")
+		return
+	}
+
+	// Check for allowed methods
+	if len(matchedHook.HTTPMethods) != 0 {
+		var allowed bool
+		for i := range matchedHook.HTTPMethods {
+			if matchedHook.HTTPMethods[i] == r.Method {
+				allowed = true
+				break
+			}
+		}
+
+		if !allowed {
+			w.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+	}
+
+	log.Printf("[%s] %s got matched\n", rid, id)
+
 	for _, responseHeader := range responseHeaders {
 		w.Header().Set(responseHeader.Name, responseHeader.Value)
 	}
 
-	id := mux.Vars(r)["id"]
+	var (
+		body []byte
+		err  error
+	)
 
-	if matchedHook := matchLoadedHook(id); matchedHook != nil {
-		log.Printf("[%s] %s got matched\n", rid, id)
+	// set contentType to IncomingPayloadContentType or header value
+	contentType := r.Header.Get("Content-Type")
+	if len(matchedHook.IncomingPayloadContentType) != 0 {
+		contentType = matchedHook.IncomingPayloadContentType
+	}
 
-		var (
-			body []byte
-			err  error
-		)
+	isMultipart := strings.HasPrefix(contentType, "multipart/form-data;")
 
-		// set contentType to IncomingPayloadContentType or header value
-		contentType := r.Header.Get("Content-Type")
-		if len(matchedHook.IncomingPayloadContentType) != 0 {
-			contentType = matchedHook.IncomingPayloadContentType
+	if !isMultipart {
+		body, err = ioutil.ReadAll(r.Body)
+		if err != nil {
+			log.Printf("[%s] error reading the request body: %+v\n", rid, err)
+		}
+	}
+
+	// parse headers
+	headers := valuesToMap(r.Header)
+
+	// parse query variables
+	query := valuesToMap(r.URL.Query())
+
+	// parse body
+	var payload map[string]interface{}
+
+	switch {
+	case strings.Contains(contentType, "json"):
+		decoder := json.NewDecoder(bytes.NewReader(body))
+		decoder.UseNumber()
+
+		err := decoder.Decode(&payload)
+		if err != nil {
+			log.Printf("[%s] error parsing JSON payload %+v\n", rid, err)
 		}
 
-		isMultipart := strings.HasPrefix(contentType, "multipart/form-data;")
-
-		if !isMultipart {
-			body, err = ioutil.ReadAll(r.Body)
-			if err != nil {
-				log.Printf("[%s] error reading the request body: %+v\n", rid, err)
-			}
+	case strings.Contains(contentType, "x-www-form-urlencoded"):
+		fd, err := url.ParseQuery(string(body))
+		if err != nil {
+			log.Printf("[%s] error parsing form payload %+v\n", rid, err)
+		} else {
+			payload = valuesToMap(fd)
 		}
 
-		// parse headers
-		headers := valuesToMap(r.Header)
+	case strings.Contains(contentType, "xml"):
+		payload, err = mxj.NewMapXmlReader(bytes.NewReader(body))
+		if err != nil {
+			log.Printf("[%s] error parsing XML payload: %+v\n", rid, err)
+		}
 
-		// parse query variables
-		query := valuesToMap(r.URL.Query())
+	case isMultipart:
+		err = r.ParseMultipartForm(*maxMultipartMem)
+		if err != nil {
+			msg := fmt.Sprintf("[%s] error parsing multipart form: %+v\n", rid, err)
+			log.Println(msg)
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, "Error occurred while parsing multipart form.")
+			return
+		}
 
-		// parse body
-		var payload map[string]interface{}
+		for k, v := range r.MultipartForm.Value {
+			log.Printf("[%s] found multipart form value %q", rid, k)
 
-		switch {
-		case strings.Contains(contentType, "json"):
-			decoder := json.NewDecoder(bytes.NewReader(body))
-			decoder.UseNumber()
-
-			err := decoder.Decode(&payload)
-			if err != nil {
-				log.Printf("[%s] error parsing JSON payload %+v\n", rid, err)
+			if payload == nil {
+				payload = make(map[string]interface{})
 			}
 
-		case strings.Contains(contentType, "x-www-form-urlencoded"):
-			fd, err := url.ParseQuery(string(body))
-			if err != nil {
-				log.Printf("[%s] error parsing form payload %+v\n", rid, err)
-			} else {
-				payload = valuesToMap(fd)
-			}
+			// TODO(moorereason): support duplicate, named values
+			payload[k] = v[0]
+		}
 
-		case strings.Contains(contentType, "xml"):
-			payload, err = mxj.NewMapXmlReader(bytes.NewReader(body))
-			if err != nil {
-				log.Printf("[%s] error parsing XML payload: %+v\n", rid, err)
-			}
-
-		case isMultipart:
-			err = r.ParseMultipartForm(*maxMultipartMem)
-			if err != nil {
-				msg := fmt.Sprintf("[%s] error parsing multipart form: %+v\n", rid, err)
-				log.Println(msg)
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprint(w, "Error occurred while parsing multipart form.")
-				return
-			}
-
-			for k, v := range r.MultipartForm.Value {
-				log.Printf("[%s] found multipart form value %q", rid, k)
-
-				if payload == nil {
-					payload = make(map[string]interface{})
+		for k, v := range r.MultipartForm.File {
+			// Force parsing as JSON regardless of Content-Type.
+			var parseAsJSON bool
+			for _, j := range matchedHook.JSONStringParameters {
+				if j.Source == "payload" && j.Name == k {
+					parseAsJSON = true
+					break
 				}
-
-				// TODO(moorereason): support duplicate, named values
-				payload[k] = v[0]
 			}
 
-			for k, v := range r.MultipartForm.File {
-				// Force parsing as JSON regardless of Content-Type.
-				var parseAsJSON bool
-				for _, j := range matchedHook.JSONStringParameters {
-					if j.Source == "payload" && j.Name == k {
+			// TODO(moorereason): we need to support multiple parts
+			// with the same name instead of just processing the first
+			// one. Will need #215 resolved first.
+
+			// MIME encoding can contain duplicate headers, so check them
+			// all.
+			if !parseAsJSON && len(v[0].Header["Content-Type"]) > 0 {
+				for _, j := range v[0].Header["Content-Type"] {
+					if j == "application/json" {
 						parseAsJSON = true
 						break
 					}
 				}
-
-				// TODO(moorereason): we need to support multiple parts
-				// with the same name instead of just processing the first
-				// one. Will need #215 resolved first.
-
-				// MIME encoding can contain duplicate headers, so check them
-				// all.
-				if !parseAsJSON && len(v[0].Header["Content-Type"]) > 0 {
-					for _, j := range v[0].Header["Content-Type"] {
-						if j == "application/json" {
-							parseAsJSON = true
-							break
-						}
-					}
-				}
-
-				if parseAsJSON {
-					log.Printf("[%s] parsing multipart form file %q as JSON\n", rid, k)
-
-					f, err := v[0].Open()
-					if err != nil {
-						msg := fmt.Sprintf("[%s] error parsing multipart form file: %+v\n", rid, err)
-						log.Println(msg)
-						w.WriteHeader(http.StatusInternalServerError)
-						fmt.Fprint(w, "Error occurred while parsing multipart form file.")
-						return
-					}
-
-					decoder := json.NewDecoder(f)
-					decoder.UseNumber()
-
-					var part map[string]interface{}
-					err = decoder.Decode(&part)
-					if err != nil {
-						log.Printf("[%s] error parsing JSON payload file: %+v\n", rid, err)
-					}
-
-					if payload == nil {
-						payload = make(map[string]interface{})
-					}
-					payload[k] = part
-				}
 			}
 
-		default:
-			log.Printf("[%s] error parsing body payload due to unsupported content type header: %s\n", rid, contentType)
-		}
+			if parseAsJSON {
+				log.Printf("[%s] parsing multipart form file %q as JSON\n", rid, k)
 
-		// handle hook
-		errors := matchedHook.ParseJSONParameters(&headers, &query, &payload)
-		for _, err := range errors {
-			log.Printf("[%s] error parsing JSON parameters: %s\n", rid, err)
-		}
-
-		var ok bool
-
-		if matchedHook.TriggerRule == nil {
-			ok = true
-		} else {
-			ok, err = matchedHook.TriggerRule.Evaluate(&headers, &query, &payload, &body, r.RemoteAddr)
-			if err != nil {
-				msg := fmt.Sprintf("[%s] error evaluating hook: %s", rid, err)
-				log.Println(msg)
-				w.WriteHeader(http.StatusInternalServerError)
-				fmt.Fprint(w, "Error occurred while evaluating hook rules.")
-				return
-			}
-		}
-
-		if ok {
-			log.Printf("[%s] %s hook triggered successfully\n", rid, matchedHook.ID)
-
-			for _, responseHeader := range matchedHook.ResponseHeaders {
-				w.Header().Set(responseHeader.Name, responseHeader.Value)
-			}
-
-			if matchedHook.CaptureCommandOutput {
-				response, err := handleHook(matchedHook, rid, &headers, &query, &payload, &body)
-
+				f, err := v[0].Open()
 				if err != nil {
+					msg := fmt.Sprintf("[%s] error parsing multipart form file: %+v\n", rid, err)
+					log.Println(msg)
 					w.WriteHeader(http.StatusInternalServerError)
-					if matchedHook.CaptureCommandOutputOnError {
-						fmt.Fprint(w, response)
-					} else {
-						w.Header().Set("Content-Type", "text/plain; charset=utf-8")
-						fmt.Fprint(w, "Error occurred while executing the hook's command. Please check your logs for more details.")
-					}
-				} else {
-					// Check if a success return code is configured for the hook
-					if matchedHook.SuccessHttpResponseCode != 0 {
-						writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.SuccessHttpResponseCode)
-					}
+					fmt.Fprint(w, "Error occurred while parsing multipart form file.")
+					return
+				}
+
+				decoder := json.NewDecoder(f)
+				decoder.UseNumber()
+
+				var part map[string]interface{}
+				err = decoder.Decode(&part)
+				if err != nil {
+					log.Printf("[%s] error parsing JSON payload file: %+v\n", rid, err)
+				}
+
+				if payload == nil {
+					payload = make(map[string]interface{})
+				}
+				payload[k] = part
+			}
+		}
+
+	default:
+		log.Printf("[%s] error parsing body payload due to unsupported content type header: %s\n", rid, contentType)
+	}
+
+	// handle hook
+	errors := matchedHook.ParseJSONParameters(&headers, &query, &payload)
+	for _, err := range errors {
+		log.Printf("[%s] error parsing JSON parameters: %s\n", rid, err)
+	}
+
+	var ok bool
+
+	if matchedHook.TriggerRule == nil {
+		ok = true
+	} else {
+		ok, err = matchedHook.TriggerRule.Evaluate(&headers, &query, &payload, &body, r.RemoteAddr)
+		if err != nil {
+			msg := fmt.Sprintf("[%s] error evaluating hook: %s", rid, err)
+			log.Println(msg)
+			w.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprint(w, "Error occurred while evaluating hook rules.")
+			return
+		}
+	}
+
+	if ok {
+		log.Printf("[%s] %s hook triggered successfully\n", rid, matchedHook.ID)
+
+		for _, responseHeader := range matchedHook.ResponseHeaders {
+			w.Header().Set(responseHeader.Name, responseHeader.Value)
+		}
+
+		if matchedHook.CaptureCommandOutput {
+			response, err := handleHook(matchedHook, rid, &headers, &query, &payload, &body)
+
+			if err != nil {
+				w.WriteHeader(http.StatusInternalServerError)
+				if matchedHook.CaptureCommandOutputOnError {
 					fmt.Fprint(w, response)
+				} else {
+					w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+					fmt.Fprint(w, "Error occurred while executing the hook's command. Please check your logs for more details.")
 				}
 			} else {
-				go handleHook(matchedHook, rid, &headers, &query, &payload, &body)
-
 				// Check if a success return code is configured for the hook
 				if matchedHook.SuccessHttpResponseCode != 0 {
 					writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.SuccessHttpResponseCode)
 				}
-
-				fmt.Fprint(w, matchedHook.ResponseMessage)
+				fmt.Fprint(w, response)
 			}
-			return
+		} else {
+			go handleHook(matchedHook, rid, &headers, &query, &payload, &body)
+
+			// Check if a success return code is configured for the hook
+			if matchedHook.SuccessHttpResponseCode != 0 {
+				writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.SuccessHttpResponseCode)
+			}
+
+			fmt.Fprint(w, matchedHook.ResponseMessage)
 		}
-
-		// Check if a return code is configured for the hook
-		if matchedHook.TriggerRuleMismatchHttpResponseCode != 0 {
-			writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.TriggerRuleMismatchHttpResponseCode)
-		}
-
-		// if none of the hooks got triggered
-		log.Printf("[%s] %s got matched, but didn't get triggered because the trigger rules were not satisfied\n", rid, matchedHook.ID)
-
-		fmt.Fprint(w, "Hook rules were not satisfied.")
-	} else {
-		w.WriteHeader(http.StatusNotFound)
-		fmt.Fprint(w, "Hook not found.")
+		return
 	}
+
+	// Check if a return code is configured for the hook
+	if matchedHook.TriggerRuleMismatchHttpResponseCode != 0 {
+		writeHttpResponseCode(w, rid, matchedHook.ID, matchedHook.TriggerRuleMismatchHttpResponseCode)
+	}
+
+	// if none of the hooks got triggered
+	log.Printf("[%s] %s got matched, but didn't get triggered because the trigger rules were not satisfied\n", rid, matchedHook.ID)
+
+	fmt.Fprint(w, "Hook rules were not satisfied.")
 }
 
 func handleHook(h *hook.Hook, rid string, headers, query, payload *map[string]interface{}, body *[]byte) (string, error) {

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -664,9 +664,9 @@ env: HOOK_head_commit.timestamp=2013-03-12T08:14:29-07:00
 	},
 
 	// test with disallowed global HTTP method
-	{"global disallowed method", "bitbucket", []string{"POST"}, "GET", nil, `{}`, "application/json", http.StatusMethodNotAllowed, ``, ``},
+	{"global disallowed method", "bitbucket", []string{"Post "}, "GET", nil, `{}`, "application/json", http.StatusMethodNotAllowed, ``, ``},
 	// test with disallowed HTTP method
-	{"disallowed method", "github", nil, "GET", nil, `{}`, "application/json", http.StatusMethodNotAllowed, ``, ``},
+	{"disallowed method", "github", nil, "Get", nil, `{}`, "application/json", http.StatusMethodNotAllowed, ``, ``},
 	// test with custom return code
 	{"empty payload", "github", nil, "POST", nil, "application/json", `{}`, http.StatusBadRequest, `Hook rules were not satisfied.`, ``},
 	// test with custom invalid http code, should default to 200 OK


### PR DESCRIPTION
The diff for `hookHandler` looks massive, but it's mostly whitespace.  I moved the "Hook not found" response up to the top of the function and got rid of the massive if-statement.  Most of the relevent changes happen before the `got matched` log message.

Returning early ("Hook not found") does prevent the response headers from being added to the response, but I'm assuming we didn't want that anyway if the hook wasn't found.  That is a "breaking change" in this PR, but the old behavior feels more like a bug, anyway.  What do you think?