### PR TITLE
Show failed parameter node lookups

### DIFF
--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -28,9 +28,9 @@ func TestGetParameter(t *testing.T) {
 		{"z.b", map[string]interface{}{"a": map[string]interface{}{"z": 2}}, nil, false},
 		{"a.2", map[string]interface{}{"a": []interface{}{"a", "b"}}, nil, false},
 	} {
-		res, ok := GetParameter(test.key, test.val)
-		if ok != test.ok {
-			t.Errorf("unexpected result given {%q, %q}: %t\n", test.key, test.val, ok)
+		res, err := GetParameter(test.key, test.val)
+		if (err == nil) != test.ok {
+			t.Errorf("unexpected result given {%q, %q}: %s\n", test.key, test.val, err)
 		}
 
 		if !reflect.DeepEqual(res, test.expect) {
@@ -225,9 +225,9 @@ var extractParameterTests = []struct {
 
 func TestExtractParameter(t *testing.T) {
 	for _, tt := range extractParameterTests {
-		value, ok := ExtractParameterAsString(tt.s, tt.params)
-		if ok != tt.ok || value != tt.value {
-			t.Errorf("failed to extract parameter %q:\nexpected {value:%#v, ok:%#v},\ngot {value:%#v, ok:%#v}", tt.s, tt.value, tt.ok, value, ok)
+		value, err := ExtractParameterAsString(tt.s, tt.params)
+		if (err == nil) != tt.ok || value != tt.value {
+			t.Errorf("failed to extract parameter %q:\nexpected {value:%#v, ok:%#v},\ngot {value:%#v, err:%s}", tt.s, tt.value, tt.ok, value, err)
 		}
 	}
 }
@@ -252,9 +252,9 @@ var argumentGetTests = []struct {
 func TestArgumentGet(t *testing.T) {
 	for _, tt := range argumentGetTests {
 		a := Argument{tt.source, tt.name, "", false}
-		value, ok := a.Get(tt.headers, tt.query, tt.payload)
-		if ok != tt.ok || value != tt.value {
-			t.Errorf("failed to get {%q, %q}:\nexpected {value:%#v, ok:%#v},\ngot {value:%#v, ok:%#v}", tt.source, tt.name, tt.value, tt.ok, value, ok)
+		value, err := a.Get(tt.headers, tt.query, tt.payload)
+		if (err == nil) != tt.ok || value != tt.value {
+			t.Errorf("failed to get {%q, %q}:\nexpected {value:%#v, ok:%#v},\ngot {value:%#v, err:%s}", tt.source, tt.name, tt.value, tt.ok, value, err)
 		}
 	}
 }
@@ -452,7 +452,7 @@ var matchRuleTests = []struct {
 	// failures
 	{"value", "", "", "X", "", Argument{"header", "a", "", false}, &map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
 	{"regex", "^X", "", "", "", Argument{"header", "a", "", false}, &map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
-	{"value", "", "2", "X", "", Argument{"header", "a", "", false}, &map[string]interface{}{"Y": "z"}, nil, nil, []byte{}, "", false, false}, // reference invalid header
+	{"value", "", "2", "X", "", Argument{"header", "a", "", false}, &map[string]interface{}{"Y": "z"}, nil, nil, []byte{}, "", false, true}, // reference invalid header
 	// errors
 	{"regex", "*", "", "", "", Argument{"header", "a", "", false}, &map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, true},                   // invalid regex
 	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, &map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
@@ -477,7 +477,7 @@ func TestMatchRule(t *testing.T) {
 		r := MatchRule{tt.typ, tt.regex, tt.secret, tt.value, tt.param, tt.ipRange}
 		ok, err := r.Evaluate(tt.headers, tt.query, tt.payload, &tt.body, tt.remoteAddr)
 		if ok != tt.ok || (err != nil) != tt.err {
-			t.Errorf("%d failed to match %#v:\nexpected ok: %#v, err: %v\ngot ok: %#v, err: %v", i, r, tt.ok, tt.err, ok, (err != nil))
+			t.Errorf("%d failed to match %#v:\nexpected ok: %#v, err: %v\ngot ok: %#v, err: %v", i, r, tt.ok, tt.err, ok, err)
 		}
 	}
 }
@@ -540,7 +540,7 @@ var andRuleTests = []struct {
 		"invalid rule",
 		AndRule{{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false}, ""}}},
 		&map[string]interface{}{"Y": "z"}, nil, nil, nil,
-		false, false,
+		false, true,
 	},
 }
 
@@ -595,7 +595,7 @@ var orRuleTests = []struct {
 			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
 		},
 		&map[string]interface{}{"Y": "Z"}, nil, nil, []byte{},
-		false, false,
+		false, true,
 	},
 }
 

--- a/webhook.go
+++ b/webhook.go
@@ -473,11 +473,15 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 	} else {
 		ok, err = matchedHook.TriggerRule.Evaluate(&headers, &query, &payload, &body, r.RemoteAddr)
 		if err != nil {
-			msg := fmt.Sprintf("[%s] error evaluating hook: %s", rid, err)
-			log.Println(msg)
-			w.WriteHeader(http.StatusInternalServerError)
-			fmt.Fprint(w, "Error occurred while evaluating hook rules.")
-			return
+			if !hook.IsParameterNodeError(err) {
+				msg := fmt.Sprintf("[%s] error evaluating hook: %s", rid, err)
+				log.Println(msg)
+				w.WriteHeader(http.StatusInternalServerError)
+				fmt.Fprint(w, "Error occurred while evaluating hook rules.")
+				return
+			}
+
+			log.Printf("[%s] %v", rid, err)
 		}
 	}
 


### PR DESCRIPTION
When attempting to match a JSON path for initial setup, it would be
helpful to know where the path failed. This change logs the failed
parameter node. For example, if you are trying to match path "a.b.d.e",
but you failed to include the "c" node, webhook will log an error
"parameter node not found: d.e" to assist in troubleshooting.