### PR TITLE
Tighten file permissions on pidfile creation

### DIFF
--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -35,10 +35,10 @@ func New(path string) (*PIDFile, error) {
 		return nil, err
 	}
 	// Note MkdirAll returns nil if a directory already exists
-	if err := MkdirAll(filepath.Dir(path), os.FileMode(0755)); err != nil {
+	if err := MkdirAll(filepath.Dir(path), os.FileMode(0o755)); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(path, []byte(fmt.Sprintf("%d", os.Getpid())), 0644); err != nil {
+	if err := ioutil.WriteFile(path, []byte(fmt.Sprintf("%d", os.Getpid())), 0o600); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
Fixes report from gosec: "G306: Expect WriteFile permissions to be 0600
or less."  Also, use new octal number formatting.