### PR TITLE
Add support for top-level JSON array in payload

### DIFF
--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -425,6 +425,57 @@ Travis sends webhooks as `payload=<JSON_STRING>`, so the payload needs to be par
 ]
 ```
 
+## JSON Array Payload
+
+If the JSON payload is an array instead of an object, `webhook` will process the payload and place it into a "root" object.
+Therefore, references to payload values must begin with `root.`.
+
+For example, given the following payload (taken from the Sendgrid Event Webhook documentation):
+```json
+[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "processed",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id"
+  },
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "deferred",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id",
+    "response": "400 try again later",
+    "attempt": "5"
+  }
+]
+```
+
+A reference to the second item in the array would look like this:
+```json
+[
+  {
+    "id": "sendgrid",
+    "execute-command": "{{ .Hookecho }}",
+    "trigger-rule": {
+      "match": {
+        "type": "value",
+        "parameter": {
+          "source": "payload",
+          "name": "root.1.event"
+        },
+        "value": "deferred"
+      }
+    }
+  }
+]
+```
+
 ## XML Payload
 
 Given the following payload:

--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -169,6 +169,22 @@
     }
   },
   {
+    "id": "sendgrid",
+    "execute-command": "{{ .Hookecho }}",
+    "command-working-directory": "/",
+    "response-message": "success",
+    "trigger-rule": {
+      "match": {
+        "type": "value",
+        "parameter": {
+          "source": "payload",
+          "name": "root.0.event"
+        },
+        "value": "processed"
+      }
+    }
+  },
+  {
     "id": "plex",
     "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",

--- a/test/hooks.yaml.tmpl
+++ b/test/hooks.yaml.tmpl
@@ -97,6 +97,18 @@
           name: "app.messages.message.#text"
         value: "Hello!!"
 
+- id: sendgrid
+  execute-command: '{{ .Hookecho }}'
+  command-working-directory: /
+  response-message: success
+  trigger-rule:
+    match:
+      type: value
+      parameter:
+        source: payload
+        name: root.0.event
+      value: processed
+
 - id: plex
   trigger-rule:
     match:

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -548,6 +548,28 @@ env: HOOK_head_commit.timestamp=2013-03-12T08:14:29-07:00
 		``,
 	},
 	{
+		"payload-json-array",
+		"sendgrid",
+		nil,
+		"POST",
+		nil,
+		"application/json",
+		`[
+  {
+    "email": "example@test.com",
+    "timestamp": 1513299569,
+    "smtp-id": "<14c5d75ce93.dfd.64b469@ismtpd-555>",
+    "event": "processed",
+    "category": "cat facts",
+    "sg_event_id": "sg_event_id",
+    "sg_message_id": "sg_message_id"
+  }
+]`,
+		http.StatusOK,
+		`success`,
+		``,
+	},
+	{
 		"multipart",
 		"plex",
 		nil,


### PR DESCRIPTION
Detect if leading character in JSON payload is an array bracket.  If
found, decode payload into an interface{} and then save the results into
payload["root"].  References to payload values would need to reference
the leading, "virtual" root node (i.e. "root.0.name").