### PR TITLE
Add Request object to hook package to simplify API

### DIFF
--- a/webhook_test.go
+++ b/webhook_test.go
@@ -53,7 +53,11 @@ func TestStaticParams(t *testing.T) {
 	b := &bytes.Buffer{}
 	log.SetOutput(b)
 
-	_, err = handleHook(spHook, "test", &spHeaders, &map[string]interface{}{}, &map[string]interface{}{}, &[]byte{})
+	r := &hook.Request{
+		ID:      "test",
+		Headers: spHeaders,
+	}
+	_, err = handleHook(spHook, r)
 	if err != nil {
 		t.Fatalf("Unexpected error: %v\n", err)
 	}


### PR DESCRIPTION
To avoid having to pass around so many parameters to the hook package,
create a Request object to store all request-specific data.  Update APIs
accordingly.