### PR TITLE
Add support to ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ os:
 arch:
   - amd64
   - arm64
+  - ppc64le
 
 matrix:
   fast_finish: true
@@ -24,6 +25,11 @@ matrix:
       arch: arm64
     - os: osx
       arch: arm64
+    - os: windows
+      arch: ppc64le
+    - os: osx
+      arch: ppc64le
+
 
 install:
   - go get -d -v -t ./...


### PR DESCRIPTION
This PR adds CI support for the IBM Power Little Endian (ppc64le) architecture. The idea is to ensure that the builds on this architecture are continuously tested along with the Intel builds (amd64) as this is part of the ubuntu distro on that architecture as well and detecting (and fixing) any issues or failures early would help to ensure that we are always up to date. For more info tag @gerrith3