### PR TITLE
Add request source

### DIFF
--- a/docs/Referencing-Request-Values.md
+++ b/docs/Referencing-Request-Values.md
@@ -1,5 +1,5 @@
 # Referencing request values
-There are three types of request values:
+There are four types of request values:
 
 1. HTTP Request Header values
 
@@ -19,7 +19,23 @@ There are three types of request values:
     }
     ```
 
-3. Payload (JSON or form-value encoded)
+3. HTTP Request parameters
+
+    ```json
+    {
+      "source": "request",
+      "name": "method"
+    }
+    ```
+
+    ```json
+    {
+      "source": "request",
+      "name": "remote-addr"
+    }
+    ```
+
+4. Payload (JSON or form-value encoded)
     ```json
     {
       "source": "payload",
@@ -57,7 +73,7 @@ There are three types of request values:
 
     If the payload contains a key with the specified name "commits.0.commit.id", then the value of that key has priority over the dot-notation referencing.
 
-3. XML Payload
+4. XML Payload
 
     Referencing XML payload parameters is much like the JSON examples above, but XML is more complex.
     Element attributes are prefixed by a hyphen (`-`).

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -454,7 +454,7 @@ func (ha *Argument) Get(r *Request) (string, error) {
 			return "", errors.New("request is nil")
 		}
 
-		switch ha.Name {
+		switch strings.ToLower(ha.Name) {
 		case "remote-addr":
 			return r.RawRequest.RemoteAddr, nil
 		case "method":

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -262,7 +262,7 @@ var argumentGetTests = []struct {
 	{"header", "a", map[string]interface{}{"A": "z"}, nil, nil, nil, "z", true},
 	{"url", "a", nil, map[string]interface{}{"a": "z"}, nil, nil, "z", true},
 	{"payload", "a", nil, nil, map[string]interface{}{"a": "z"}, nil, "z", true},
-	{"request", "method", nil, nil, map[string]interface{}{"a": "z"}, &http.Request{Method: "POST", RemoteAddr: "127.0.0.1:1234"}, "POST", true},
+	{"request", "METHOD", nil, nil, map[string]interface{}{"a": "z"}, &http.Request{Method: "POST", RemoteAddr: "127.0.0.1:1234"}, "POST", true},
 	{"request", "remote-addr", nil, nil, map[string]interface{}{"a": "z"}, &http.Request{Method: "POST", RemoteAddr: "127.0.0.1:1234"}, "127.0.0.1:1234", true},
 	{"string", "a", nil, nil, map[string]interface{}{"a": "z"}, nil, "a", true},
 	// failures

--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -253,6 +253,21 @@
     "include-command-output-in-response-on-error": true
   },
   {
+    "id": "request-source",
+    "pass-arguments-to-command": [
+      {
+        "source": "request",
+        "name": "method"
+      },
+      {
+        "source": "request",
+        "name": "remote-addr"
+      }
+    ],
+    "execute-command": "{{ .Hookecho }}",
+    "include-command-output-in-response": true
+  },
+  {
     "id": "static-params-ok",
 		"execute-command": "{{ .Hookecho }}",
 		"response-message": "success",

--- a/test/hooks.yaml.tmpl
+++ b/test/hooks.yaml.tmpl
@@ -152,6 +152,15 @@
   include-command-output-in-response: true
   include-command-output-in-response-on-error: true
 
+- id: request-source
+  pass-arguments-to-command:
+  - source: request
+    name: method
+  - source: request
+    name: remote-addr
+  execute-command: '{{ .Hookecho }}'
+  include-command-output-in-response: true
+
 - id: static-params-ok
   execute-command: '{{ .Hookecho }}'
   include-command-output-in-response: true


### PR DESCRIPTION
Add "request" source with support for "method" and "remote-addr"
parameters.  Both values are taken from the raw http.Request object.

Fixes #312