### PR TITLE
Add option to send raw request body to command

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -31,15 +31,16 @@ import (
 
 // Constants used to specify the parameter source
 const (
-	SourceHeader        string = "header"
-	SourceQuery         string = "url"
-	SourceQueryAlias    string = "query"
-	SourcePayload       string = "payload"
-	SourceRequest       string = "request"
-	SourceString        string = "string"
-	SourceEntirePayload string = "entire-payload"
-	SourceEntireQuery   string = "entire-query"
-	SourceEntireHeaders string = "entire-headers"
+	SourceHeader         string = "header"
+	SourceQuery          string = "url"
+	SourceQueryAlias     string = "query"
+	SourcePayload        string = "payload"
+	SourceRawRequestBody string = "raw-request-body"
+	SourceRequest        string = "request"
+	SourceString         string = "string"
+	SourceEntirePayload  string = "entire-payload"
+	SourceEntireQuery    string = "entire-query"
+	SourceEntireHeaders  string = "entire-headers"
 )
 
 const (
@@ -448,6 +449,9 @@ func (ha *Argument) Get(r *Request) (string, error) {
 
 	case SourceString:
 		return ha.Name, nil
+
+	case SourceRawRequestBody:
+		return string(r.Body), nil
 
 	case SourceRequest:
 		if r == nil || r.RawRequest == nil {

--- a/test/hooks.json.tmpl
+++ b/test/hooks.json.tmpl
@@ -169,6 +169,17 @@
     }
   },
   {
+    "id": "txt-raw",
+    "execute-command": "{{ .Hookecho }}",
+    "command-working-directory": "/",
+    "include-command-output-in-response": true,
+    "pass-arguments-to-command": [
+      {
+        "source": "raw-request-body"
+      }
+    ]
+  },
+  {
     "id": "sendgrid",
     "execute-command": "{{ .Hookecho }}",
     "command-working-directory": "/",

--- a/test/hooks.yaml.tmpl
+++ b/test/hooks.yaml.tmpl
@@ -97,6 +97,13 @@
           name: "app.messages.message.#text"
         value: "Hello!!"
 
+- id: txt-raw
+  execute-command: '{{ .Hookecho }}'
+  command-working-directory: /
+  include-command-output-in-response: true
+  pass-arguments-to-command:
+  - source: raw-request-body
+
 - id: sendgrid
   execute-command: '{{ .Hookecho }}'
   command-working-directory: /

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -573,6 +573,25 @@ env: HOOK_head_commit.timestamp=2013-03-12T08:14:29-07:00
 		``,
 	},
 	{
+		"txt-raw",
+		"txt-raw",
+		nil,
+		"POST",
+		map[string]string{"Content-Type": "text/plain"},
+		"text/plain",
+		`# FOO
+
+blah
+blah`,
+		false,
+		http.StatusOK,
+		`# FOO
+
+blah
+blah`,
+		``,
+	},
+	{
 		"payload-json-array",
 		"sendgrid",
 		nil,


### PR DESCRIPTION
The existing `entire-payload` option sends a JSON representation of the
parsed request body.  Add a new `raw-request-body` source to send the
raw request body.

Fixes #439