### PR TITLE
Allow tests to run on systems that use busybox (such as Alpine)

### DIFF
--- a/webhook_test.go
+++ b/webhook_test.go
@@ -33,7 +33,8 @@ func TestStaticParams(t *testing.T) {
 	spHeaders["Accept"] = "*/*"
 
 	// case 2: binary with spaces in its name
-	err := os.Symlink("/bin/echo", "/tmp/with space")
+	d1 := []byte("#!/bin/sh\n/bin/echo\n")
+	err := ioutil.WriteFile("/tmp/with space", d1, 0755)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}


### PR DESCRIPTION
Alpine uses busybox, which implements standard utilities (like 'echo') in a single binary, using the invoked command to determine what needs to be done. This means if you create another link to /bin/echo, busybox does not know what command should be run, and exits with an error.

This change creates a simple shell script that runs echo, and uses this when testing.