### PR TITLE
Fix 'err:parameter node not found' for dotted reference

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -394,14 +394,22 @@ func GetParameter(s string, params interface{}) (interface{}, error) {
 			return v, nil
 		}
 
-		// Checked for dotted references
-		p := strings.SplitN(s, ".", 2)
-		if pValue, ok := params.(map[string]interface{})[p[0]]; ok {
-			if len(p) > 1 {
-				return GetParameter(p[1], pValue)
+		// Check for dotted references
+		p := strings.Split(s, ".")
+		ref := ""
+		for i := range p {
+			if i == 0 {
+				ref = p[i]
+			} else {
+				ref += "." + p[i]
 			}
-
-			return pValue, nil
+			if pValue, ok := params.(map[string]interface{})[ref]; ok {
+				if i == len(p)-1 {
+					return pValue, nil
+				} else {
+					return GetParameter(strings.Join(p[i+1:], "."), pValue)
+				}
+			}
 		}
 	}
 

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -231,6 +231,8 @@ var extractParameterTests = []struct {
 	{"b", map[string]interface{}{"b": map[string]interface{}{"z": 1}}, `{"z":1}`, true},
 	{"c", map[string]interface{}{"c": []interface{}{"y", "z"}}, `["y","z"]`, true},
 	{"d", map[string]interface{}{"d": [2]interface{}{"y", "z"}}, `["y","z"]`, true},
+	{"a.b.c.1", map[string]interface{}{"a": map[string]interface{}{"b": map[string]interface{}{"c.1": "z"}}}, "z", true},
+	{"a.b.1.c", map[string]interface{}{"a": map[string]interface{}{"b.1": map[string]interface{}{"c": "z"}}}, "z", true},
 	// failures
 	{"check_nil", nil, "", false},
 	{"a.X", map[string]interface{}{"a": map[string]interface{}{"b": "z"}}, "", false},                                                      // non-existent parameter reference


### PR DESCRIPTION
I had a problem with a [harbor webhook](https://goharbor.io/docs/1.10/working-with-projects/project-configuration/configure-webhooks/)
Part of the payload sent by the IMAGE SCAN COMPLETED notification, is:
```
         "scan_overview": {
           "application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0": {
             "complete_percent": 100,
             "duration": 42,

             "end_time": "2021-01-22T20:27:27.404922Z",
             "report_id": "87962b6f-589c-4dbf-9972-2646cae2cee4",
             "scan_status": "Success",
             "scanner": {
               "name": "Trivy",
               "vendor": "Aqua Security",
               "version": "v0.9.2"
             },
             "severity": "Medium",
             "start_time": "2021-01-22T20:26:45.096622Z",
             "summary": {
               "fixable": 6,
               "summary": {
                 "Low": 21,
                 "Medium": 7
               },
               "total": 28
             }
           }
         },
```
In order to extract the "Severity" i have to use the path: 
```
scan_overview.application/vnd.scanner.adapter.vuln.report.harbor+json; version=1.0.severity
``` 
This gave error "parameter node not found', because paths with dotted references only worked when the reference with the dots was at the end of the path.
This change fixes that.