### PR TITLE
Update example: Github hook X-Hub-Signature type

### DIFF
--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -51,7 +51,7 @@ although the examples on this page all use the JSON format.
         {
           "match":
           {
-            "type": "payload-hmac-sha1",
+            "type": "payload-hash-sha1",
             "secret": "mysecret",
             "parameter":
             {


### PR DESCRIPTION
Setting this up for the first time. I found this to not work, until I changed the type as it is written here: https://davidauthier.com/blog/2017/09/07/deploy-using-github-webhooks/