### PR TITLE
Clarify version number for which the example works

### DIFF
--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -23,6 +23,9 @@ although the examples on this page all use the JSON format.
 * [Pass string arguments to command](#pass-string-arguments-to-command)
 
 ## Incoming Github webhook
+
+This example works on 2.8+ versions of Webhook - if you are on a previous series, change `payload-hmac-sha1` to `payload-hash-sha1`.
+
 ```json
 [
   {


### PR DESCRIPTION
#461 changed option name and in https://github.com/adnanh/webhook/pull/528#issuecomment-826165812, @moorereason suggests to look at old tags of example documentation. This would mean that users have to read through random old documentation to discover why their packaged version doesn't work . Suggesting that clarity in the examples is preferable.

Recall that renaming this sort of option doesn't give the user some easy exception message. It just causes the trigger to not be satisfied, so there are A LOT of options for debugging. Branch name? secret? Yaml syntax? Does the shared secret need to be hashed in some way? How does the secret hashing even work?

(which takes a lot of time to do, so that's why this information is important)