### PR TITLE
Removed snap from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,6 @@ $ go build github.com/adnanh/webhook
 to build the latest version of the [webhook][w].
 
 ### Using package manager
-#### Snap store
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-white.svg)](https://snapcraft.io/webhook)
 
 #### Ubuntu
 If you are using Ubuntu linux (17.04 or later), you can install webhook using `sudo apt-get install webhook` which will install community packaged version.


### PR DESCRIPTION
Looks like no one support snap version, and there is a major bug in it, adnanh#530 that nobody trying to fix.
This is not some minor stuff - the main scenario of using webhook is completely broken - you can't execute a shell script.
So I suggest to remove snap from README.md while it is broken (and return it back after adnanh#530 fixed).