### PR TITLE
Fix broken link for guide to Jira and webhook integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Check out [Hook examples page](docs/Hook-Examples.md) for more complex examples 
 
 ### Guides featuring webhook
  - [Plex 2 Telegram](https://gitlab.com/-/snippets/1972594) by [@psyhomb](https://github.com/psyhomb)
- - [Webhook & JIRA](https://sites.google.com/site/mrxpalmeiras/notes/jira-webhooks) by [@perfecto25](https://github.com/perfecto25)
+ - [Webhook & JIRA](https://sites.google.com/site/mrxpalmeiras/more/jira-webhooks) by [@perfecto25](https://github.com/perfecto25)
  - [Trigger Ansible AWX job runs on SCM (e.g. git) commit](http://jpmens.net/2017/10/23/trigger-awx-job-runs-on-scm-commit/) by [@jpmens](http://mens.de/)
  - [Deploy using GitHub webhooks](https://davidauthier.wearemd.com/blog/deploy-using-github-webhooks.html) by [@awea](https://davidauthier.wearemd.com)
  - [Setting up Automatic Deployment and Builds Using Webhooks](https://willbrowning.me/setting-up-automatic-deployment-and-builds-using-webhooks/) by [Will Browning](https://willbrowning.me/about/)

--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -312,7 +312,7 @@ __Not recommended in production due to low security__
 ```
 
 ## JIRA Webhooks
-[Guide by @perfecto25](https://sites.google.com/site/mrxpalmeiras/notes/jira-webhooks)
+[Guide by @perfecto25](https://sites.google.com/site/mrxpalmeiras/more/jira-webhooks)
 
 ## Pass File-to-command sample
 


### PR DESCRIPTION
Hello Adnan! Firstly, thank you very much for this amazing project!

Whilst browsing through the various documentations and guides, I noticed that the ones for Jira and webhook integration had changed the resource locations. Thus, the PR to update those. There were two instances of this specific issue and i've fixed both of them.

Other than this, all the external links to other guides seem to be working well.

Signed-off-by: Prince Mendiratta <prince.mendi@gmail.com>