### PR TITLE
changed src of hookdoo, previous img url was broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you use Mattermost or Slack, you can set up an "Outgoing webhook integration"
 Everything else is the responsibility of the command's author.
 
 # Hookdoo
-<a href="https://www.hookdoo.com/?github"><img src="https://www.hookdoo.com/logo/logo.svg" height="96" alt="hookdoo" align="left" /></a>
+<a href="https://www.hookdoo.com/?github"><img src="https://hookdoo.com/img/Hookdoo_Logo_1.png" height="96" alt="hookdoo" align="left" /></a>
 
 If you don't have time to waste configuring, hosting, debugging and maintaining your webhook instance, we offer a __SaaS__ solution that has all of the capabilities webhook provides, plus a lot more, and all that packaged in a nice friendly web interface. If you are interested, find out more at [hookdoo website](https://www.hookdoo.com/?ref=github-webhook-readme). If you have any questions, you can contact us at info@hookdoo.com
 


### PR DESCRIPTION
This PR modifies the `src` URL of Hookdoo in `README.md`, it was formerly seen as:
---------------------------------
![image](https://user-images.githubusercontent.com/20269286/219651903-8a0d4fe7-bd02-4a97-8a16-8f231340641d.png)
---------------------------------

I have added the new URL currently present on the official page of Hookdoo: `https://hookdoo.com/img/Hookdoo_Logo_1.png`

**P.S. I am new to open-source contribution, I'm all ears to feedback and please let me know if there are any issues you'd like me to solve regarding Python, JavaScript, and Frontend!**