### PR TITLE
docs: fix example json in template.md

### DIFF
--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -9,21 +9,20 @@ In additional to the [built-in Go template functions and features][tt], `webhook
 In the example JSON template file below (YAML is also supported), the `payload-hmac-sha1` matching rule looks up the HMAC secret from the environment using the `getenv` template function.
 Additionally, the result is piped through the built-in Go template function `js` to ensure that the result is a well-formed Javascript/JSON string.
 
-```
+```json
+[
   {
     "id": "webhook",
     "execute-command": "/home/adnan/redeploy-go-webhook.sh",
     "command-working-directory": "/home/adnan/go",
     "response-message": "I got the payload!",
-    "response-headers":
-    [
+    "response-headers": [
       {
         "name": "Access-Control-Allow-Origin",
         "value": "*"
       }
     ],
-    "pass-arguments-to-command":
-    [
+    "pass-arguments-to-command": [
       {
         "source": "payload",
         "name": "head_commit.id"
@@ -37,29 +36,23 @@ Additionally, the result is piped through the built-in Go template function `js`
         "name": "pusher.email"
       }
     ],
-    "trigger-rule":
-    {
-      "and":
-      [
+    "trigger-rule": {
+      "and": [
         {
-          "match":
-          {
+          "match": {
             "type": "payload-hmac-sha1",
-            "secret": "{{ getenv "XXXTEST_SECRET" | js }}",
-            "parameter":
-            {
+            "secret": "{{ getenv \"XXXTEST_SECRET\" | js }}",
+            "parameter": {
               "source": "header",
               "name": "X-Hub-Signature"
             }
           }
         },
         {
-          "match":
-          {
+          "match": {
             "type": "value",
             "value": "refs/heads/master",
-            "parameter":
-            {
+            "parameter": {
               "source": "payload",
               "name": "ref"
             }
@@ -69,7 +62,6 @@ Additionally, the result is piped through the built-in Go template function `js`
     }
   }
 ]
-
 ```
 
 [w]: https://github.com/adnanh/webhook


### PR DESCRIPTION
Adds missing bracket.
Escapes quotes within a string.
Reformats whole example.

fixes #627