### PR TITLE
Use additional headers in the signature payload:

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -434,10 +434,11 @@ func ExtractParameterAsString(s string, params interface{}) (string, error) {
 // Argument type specifies the parameter key name and the source it should
 // be extracted from
 type Argument struct {
-	Source       string `json:"source,omitempty"`
-	Name         string `json:"name,omitempty"`
-	EnvName      string `json:"envname,omitempty"`
-	Base64Decode bool   `json:"base64decode,omitempty"`
+	Source                  string   `json:"source,omitempty"`
+	Name                    string   `json:"name,omitempty"`
+	EnvName                 string   `json:"envname,omitempty"`
+	Base64Decode            bool     `json:"base64decode,omitempty"`
+	SignaturePayloadHeaders []string `json:"headers-to-add-to-signature-payload,omitempty"`
 }
 
 // Get Argument method returns the value for the Argument's key name
@@ -919,6 +920,7 @@ func (r MatchRule) Evaluate(req *Request) (bool, error) {
 
 	arg, err := r.Parameter.Get(req)
 	if err == nil {
+		payload := r.signaturePayload(req.Body, req.Headers)
 		switch r.Type {
 		case MatchValue:
 			return compare(arg, r.Value), nil
@@ -928,23 +930,37 @@ func (r MatchRule) Evaluate(req *Request) (bool, error) {
 			log.Print(`warn: use of deprecated option payload-hash-sha1; use payload-hmac-sha1 instead`)
 			fallthrough
 		case MatchHMACSHA1:
-			_, err := CheckPayloadSignature(req.Body, r.Secret, arg)
+			_, err := CheckPayloadSignature(payload, r.Secret, arg)
 			return err == nil, err
 		case MatchHashSHA256:
 			log.Print(`warn: use of deprecated option payload-hash-sha256: use payload-hmac-sha256 instead`)
 			fallthrough
 		case MatchHMACSHA256:
-			_, err := CheckPayloadSignature256(req.Body, r.Secret, arg)
+			_, err := CheckPayloadSignature256(payload, r.Secret, arg)
 			return err == nil, err
 		case MatchHashSHA512:
 			log.Print(`warn: use of deprecated option payload-hash-sha512: use payload-hmac-sha512 instead`)
 			fallthrough
 		case MatchHMACSHA512:
-			_, err := CheckPayloadSignature512(req.Body, r.Secret, arg)
+			_, err := CheckPayloadSignature512(payload, r.Secret, arg)
 			return err == nil, err
 		}
 	}
 	return false, err
+}
+
+func (r MatchRule) signaturePayload(body []byte, headers map[string]interface{}) []byte {
+	if len(r.Parameter.SignaturePayloadHeaders) > 0 {
+		for _, elem := range r.Parameter.SignaturePayloadHeaders {
+			h, found := headers[elem]
+			header := fmt.Sprintf("%s", h)
+			if found && header != "" {
+				body = append(body, []byte(header)...)
+			}
+		}
+	}
+
+	return body
 }
 
 // compare is a helper function for constant time string comparisons.

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -274,7 +274,7 @@ var argumentGetTests = []struct {
 
 func TestArgumentGet(t *testing.T) {
 	for _, tt := range argumentGetTests {
-		a := Argument{tt.source, tt.name, "", false}
+		a := Argument{tt.source, tt.name, "", false, nil}
 		r := &Request{
 			Headers:    tt.headers,
 			Query:      tt.query,
@@ -294,14 +294,14 @@ var hookParseJSONParametersTests = []struct {
 	rheaders, rquery, rpayload map[string]interface{}
 	ok                         bool
 }{
-	{[]Argument{Argument{"header", "a", "", false}}, map[string]interface{}{"A": `{"b": "y"}`}, nil, nil, map[string]interface{}{"A": map[string]interface{}{"b": "y"}}, nil, nil, true},
-	{[]Argument{Argument{"url", "a", "", false}}, nil, map[string]interface{}{"a": `{"b": "y"}`}, nil, nil, map[string]interface{}{"a": map[string]interface{}{"b": "y"}}, nil, true},
-	{[]Argument{Argument{"payload", "a", "", false}}, nil, nil, map[string]interface{}{"a": `{"b": "y"}`}, nil, nil, map[string]interface{}{"a": map[string]interface{}{"b": "y"}}, true},
-	{[]Argument{Argument{"header", "z", "", false}}, map[string]interface{}{"Z": `{}`}, nil, nil, map[string]interface{}{"Z": map[string]interface{}{}}, nil, nil, true},
+	{[]Argument{Argument{"header", "a", "", false, nil}}, map[string]interface{}{"A": `{"b": "y"}`}, nil, nil, map[string]interface{}{"A": map[string]interface{}{"b": "y"}}, nil, nil, true},
+	{[]Argument{Argument{"url", "a", "", false, nil}}, nil, map[string]interface{}{"a": `{"b": "y"}`}, nil, nil, map[string]interface{}{"a": map[string]interface{}{"b": "y"}}, nil, true},
+	{[]Argument{Argument{"payload", "a", "", false, nil}}, nil, nil, map[string]interface{}{"a": `{"b": "y"}`}, nil, nil, map[string]interface{}{"a": map[string]interface{}{"b": "y"}}, true},
+	{[]Argument{Argument{"header", "z", "", false, nil}}, map[string]interface{}{"Z": `{}`}, nil, nil, map[string]interface{}{"Z": map[string]interface{}{}}, nil, nil, true},
 	// failures
-	{[]Argument{Argument{"header", "z", "", false}}, map[string]interface{}{"Z": ``}, nil, nil, map[string]interface{}{"Z": ``}, nil, nil, false},     // empty string
-	{[]Argument{Argument{"header", "y", "", false}}, map[string]interface{}{"X": `{}`}, nil, nil, map[string]interface{}{"X": `{}`}, nil, nil, false}, // missing parameter
-	{[]Argument{Argument{"string", "z", "", false}}, map[string]interface{}{"Z": ``}, nil, nil, map[string]interface{}{"Z": ``}, nil, nil, false},     // invalid argument source
+	{[]Argument{Argument{"header", "z", "", false, nil}}, map[string]interface{}{"Z": ``}, nil, nil, map[string]interface{}{"Z": ``}, nil, nil, false},     // empty string
+	{[]Argument{Argument{"header", "y", "", false, nil}}, map[string]interface{}{"X": `{}`}, nil, nil, map[string]interface{}{"X": `{}`}, nil, nil, false}, // missing parameter
+	{[]Argument{Argument{"string", "z", "", false, nil}}, map[string]interface{}{"Z": ``}, nil, nil, map[string]interface{}{"Z": ``}, nil, nil, false},     // invalid argument source
 }
 
 func TestHookParseJSONParameters(t *testing.T) {
@@ -326,9 +326,9 @@ var hookExtractCommandArgumentsTests = []struct {
 	value                   []string
 	ok                      bool
 }{
-	{"test", []Argument{Argument{"header", "a", "", false}}, map[string]interface{}{"A": "z"}, nil, nil, []string{"test", "z"}, true},
+	{"test", []Argument{Argument{"header", "a", "", false, nil}}, map[string]interface{}{"A": "z"}, nil, nil, []string{"test", "z"}, true},
 	// failures
-	{"fail", []Argument{Argument{"payload", "a", "", false}}, map[string]interface{}{"A": "z"}, nil, nil, []string{"fail", ""}, false},
+	{"fail", []Argument{Argument{"payload", "a", "", false, nil}}, map[string]interface{}{"A": "z"}, nil, nil, []string{"fail", ""}, false},
 }
 
 func TestHookExtractCommandArguments(t *testing.T) {
@@ -375,14 +375,14 @@ var hookExtractCommandArgumentsForEnvTests = []struct {
 	// successes
 	{
 		"test",
-		[]Argument{Argument{"header", "a", "", false}},
+		[]Argument{Argument{"header", "a", "", false, nil}},
 		map[string]interface{}{"A": "z"}, nil, nil,
 		[]string{"HOOK_a=z"},
 		true,
 	},
 	{
 		"test",
-		[]Argument{Argument{"header", "a", "MYKEY", false}},
+		[]Argument{Argument{"header", "a", "MYKEY", false, nil}},
 		map[string]interface{}{"A": "z"}, nil, nil,
 		[]string{"MYKEY=z"},
 		true,
@@ -390,7 +390,7 @@ var hookExtractCommandArgumentsForEnvTests = []struct {
 	// failures
 	{
 		"fail",
-		[]Argument{Argument{"payload", "a", "", false}},
+		[]Argument{Argument{"payload", "a", "", false, nil}},
 		map[string]interface{}{"A": "z"}, nil, nil,
 		[]string{},
 		false,
@@ -489,24 +489,24 @@ var matchRuleTests = []struct {
 	ok                                 bool
 	err                                bool
 }{
-	{"value", "", "", "z", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
-	{"regex", "^z", "", "z", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
-	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
+	{"value", "", "", "z", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
+	{"regex", "^z", "", "z", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
+	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
+	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
+	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
+	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
 	// failures
-	{"value", "", "", "X", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
-	{"regex", "^X", "", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
-	{"value", "", "2", "X", "", Argument{"header", "a", "", false}, map[string]interface{}{"Y": "z"}, nil, nil, []byte{}, "", false, true}, // reference invalid header
+	{"value", "", "", "X", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
+	{"regex", "^X", "", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
+	{"value", "", "2", "X", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"Y": "z"}, nil, nil, []byte{}, "", false, true}, // reference invalid header
 	// errors
-	{"regex", "*", "", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, true},                   // invalid regex
-	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
-	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
-	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hmac-sha512", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hash-sha512", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"regex", "*", "", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, true},                   // invalid regex
+	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
+	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
+	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"payload-hmac-sha512", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"payload-hash-sha512", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
 	// IP whitelisting, valid cases
 	{"ip-whitelist", "", "", "", "192.168.0.1/24", Argument{}, nil, nil, nil, []byte{}, "192.168.0.2:9000", true, false}, // valid IPv4, with range
 	{"ip-whitelist", "", "", "", "192.168.0.1/24", Argument{}, nil, nil, nil, []byte{}, "192.168.0.2:9000", true, false}, // valid IPv4, with range
@@ -552,8 +552,8 @@ var andRuleTests = []struct {
 	{
 		"(a=z, b=y): a=z && b=y",
 		AndRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "z", "B": "y"}, nil, nil,
 		[]byte{},
@@ -562,8 +562,8 @@ var andRuleTests = []struct {
 	{
 		"(a=z, b=Y): a=z && b=y",
 		AndRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "z", "B": "Y"}, nil, nil,
 		[]byte{},
@@ -573,22 +573,22 @@ var andRuleTests = []struct {
 	{
 		"(a=z, b=y, c=x, d=w=, e=X, f=X): a=z && (b=y && c=x) && (d=w || e=v) && !f=u",
 		AndRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
 			{
 				And: &AndRule{
-					{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
-					{Match: &MatchRule{"value", "", "", "x", Argument{"header", "c", "", false}, ""}},
+					{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
+					{Match: &MatchRule{"value", "", "", "x", Argument{"header", "c", "", false, nil}, ""}},
 				},
 			},
 			{
 				Or: &OrRule{
-					{Match: &MatchRule{"value", "", "", "w", Argument{"header", "d", "", false}, ""}},
-					{Match: &MatchRule{"value", "", "", "v", Argument{"header", "e", "", false}, ""}},
+					{Match: &MatchRule{"value", "", "", "w", Argument{"header", "d", "", false, nil}, ""}},
+					{Match: &MatchRule{"value", "", "", "v", Argument{"header", "e", "", false, nil}, ""}},
 				},
 			},
 			{
 				Not: &NotRule{
-					Match: &MatchRule{"value", "", "", "u", Argument{"header", "f", "", false}, ""},
+					Match: &MatchRule{"value", "", "", "u", Argument{"header", "f", "", false, nil}, ""},
 				},
 			},
 		},
@@ -600,7 +600,7 @@ var andRuleTests = []struct {
 	// failures
 	{
 		"invalid rule",
-		AndRule{{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false}, ""}}},
+		AndRule{{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false, nil}, ""}}},
 		map[string]interface{}{"Y": "z"}, nil, nil, nil,
 		false, true,
 	},
@@ -632,8 +632,8 @@ var orRuleTests = []struct {
 	{
 		"(a=z, b=X): a=z || b=y",
 		OrRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "z", "B": "X"}, nil, nil,
 		[]byte{},
@@ -642,8 +642,8 @@ var orRuleTests = []struct {
 	{
 		"(a=X, b=y): a=z || b=y",
 		OrRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "X", "B": "y"}, nil, nil,
 		[]byte{},
@@ -652,8 +652,8 @@ var orRuleTests = []struct {
 	{
 		"(a=Z, b=Y): a=z || b=y",
 		OrRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "Z", "B": "Y"}, nil, nil,
 		[]byte{},
@@ -663,7 +663,7 @@ var orRuleTests = []struct {
 	{
 		"missing parameter node",
 		OrRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"Y": "Z"}, nil, nil,
 		[]byte{},
@@ -694,8 +694,8 @@ var notRuleTests = []struct {
 	ok                      bool
 	err                     bool
 }{
-	{"(a=z): !a=X", NotRule{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false}, ""}}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, true, false},
-	{"(a=z): !a=z", NotRule{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, false, false},
+	{"(a=z): !a=X", NotRule{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false, nil}, ""}}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, true, false},
+	{"(a=z): !a=z", NotRule{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, false, false},
 }
 
 func TestNotRule(t *testing.T) {


### PR DESCRIPTION
Use additional headers in the signature payload:

This will allow users to use headers in the signature payload during the verification process. For example, a timestamp header can be used to validate if requests have been sent recently and reduce the risk of message replays.

Fixes: #643 