### PR TITLE
Add Zola Guide to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Check out [Hook examples page](docs/Hook-Examples.md) for more complex examples 
  - VIDEO: [Gitlab CI/CD configuration using Docker and adnanh/webhook to deploy on VPS - Tutorial #1](https://www.youtube.com/watch?v=Qhn-lXjyrZA&feature=youtu.be) by [Yes! Let's Learn Software Engineering](https://www.youtube.com/channel/UCH4XJf2BZ_52fbf8fOBMF3w)
  - [Integrate automatic deployment in 20 minutes using webhooks + Nginx setup](https://anksus.me/blog/integrate-automatic-deployment-in-20-minutes-using-webhooks) by [Anksus](https://github.com/Anksus)
  - [Automatically redeploy your static blog with Gitea, Uberspace & Webhook](https://by.arran.nz/posts/code/webhook-deploy/) by [Arran](https://arran.nz)
+- [Automatically Updating My Zola Site Using a Webhook](https://osc.garden/blog/updating-site-with-webhook/) by [Óscar Fernández](https://osc.garden/)
  - ...
  - Want to add your own? Open an Issue or create a PR :-)
  


### PR DESCRIPTION
Hi!

I just published [an article](https://osc.garden/blog/updating-site-with-webhook/) (also available in [Spanish](https://osc.garden/es/blog/updating-site-with-webhook/) and [Catalan](https://osc.garden/ca/blog/updating-site-with-webhook/)) explaining how I got my [Zola](https://www.getzola.org/) site to automatically update whenever its repository receives a push.

It explains how to create the building script for Zola, set up webhook, open the necessary port, use SSL, set up a secret, and set up a "hardened" systemd service.

I didn't see other guides referring to Zola, so I'm hoping this is useful to others.

Cheers,
Óscar