### PR TITLE
fix: use CGO_ENABLED=0 for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ release: clean deps ## Generate releases for unix systems
 		do \
 			echo "Building $$os-$$arch"; \
 			mkdir -p build/webhook-$$os-$$arch/; \
-			GOOS=$$os GOARCH=$$arch go build -o build/webhook-$$os-$$arch/webhook; \
+			CGO_ENABLED=0 GOOS=$$os GOARCH=$$arch go build -o build/webhook-$$os-$$arch/webhook; \
 			tar cz -C build -f build/webhook-$$os-$$arch.tar.gz webhook-$$os-$$arch; \
 		done \
 	done


### PR DESCRIPTION
Ensure that release builds are built with cgo disabled.  This is usually the case for cross-compiled builds anyway, but adding this flag makes builds consistent regardless of what platform they are being built on.

In particular, without `CGO_ENABLED=0`, if you make the release builds on a linux/amd64 system then the linux/amd64 binary is dynamically linked against the system libc _of the build machine_, meaning a binary built on a glibc-based system like Ubuntu will not work on a musl libc system like Alpine.  This is what appears to have happened for release 2.8.1.

But the same source code built on a different system (e.g. darwin/arm64) would cross-compile the linux/amd64 binary with cgo disabled, making a static binary that works on both glibc and musl systems.  This is what appears to have happened for release 2.8.2.

Setting `CGO_ENABLED=0` in the Makefile will make the behaviour consistent for future releases, producing static binaries for the linux builds in all cases, whatever the build platform.

Fixes #684 