### PR TITLE
Proposal: more flexible argument extraction and signature testing

### DIFF
--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -25,7 +25,7 @@ although the examples on this page all use the JSON format.
 
 ## Incoming Github webhook
 
-This example works on 2.8+ versions of Webhook - if you are on a previous series, change `payload-hmac-sha1` to `payload-hash-sha1`.
+This example works on 2.9+ versions of Webhook - if you are on a previous series, change the `check-signature` block to an equivalent `match` block, see the [Hook-Rules](Hook-Rules.md#legacy-match-rules-for-signatures) page for full details.
 
 ```json
 [
@@ -53,11 +53,11 @@ This example works on 2.8+ versions of Webhook - if you are on a previous series
       "and":
       [
         {
-          "match":
+          "check-signature":
           {
-            "type": "payload-hmac-sha1",
+            "algorithm": "sha1",
             "secret": "mysecret",
-            "parameter":
+            "signature":
             {
               "source": "header",
               "name": "X-Hub-Signature"
@@ -185,11 +185,11 @@ Values in the request body can be accessed in the command or to the match rule b
       "and":
       [
         {
-          "match":
+          "check-signature":
           {
-            "type": "payload-hmac-sha256",
+            "algorithm": "sha256",
             "secret": "mysecret",
-            "parameter":
+            "signature":
             {
               "source": "header",
               "name": "X-Gogs-Signature"

--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -73,5 +73,33 @@ Additionally, the result is piped through the built-in Go template function `js`
 
 ```
 
+## Changing the template delimiters
+
+If your hook configuration includes lookup arguments of type `{"source": "template"}`, and you also need to parse the hooks file _as_ a template, you can use the `-template-delims` parameter to change the template delimiter used when processing the hook file so it does not clash with the standard `{{ ... }}` delimiters used for template lookups.  The parameter is a comma-separated pair of the left and right delimiter strings, e.g. `-template-delims='[[,]]'` would use square brackets.  For a configuration like this:
+
+```json
+[
+  {
+    "id": "example",
+    "trigger-rule": {
+      "check-signature": {
+        "algorithm": "sha256",
+        "secret": "[[ getenv `XXXTEST_SECRET` | js ]]",
+        "signature": {
+          "source": "header",
+          "name": "X-Signature"
+        },
+        "string-to-sign": {
+          "source": "template",
+          "name": "{{ .BodyText }}{{ .GetHeader `date` }}"
+        }
+      }
+    }
+  }
+]
+```
+
+the `-template-delims='[[,]]'` setting would cause the `getenv` part to be interpreted when parsing the hook file, whereas the string-to-sign template would be executed when evaluating the trigger rule against each request.
+
 [w]: https://github.com/adnanh/webhook
 [tt]: https://golang.org/pkg/text/template/

--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -1092,7 +1092,7 @@ func (r SignatureRule) Evaluate(req *Request) (bool, error) {
 	// find the signature
 	sig, err := r.Signature.Get(req)
 	if err != nil {
-		return false, fmt.Errorf("could not extract signature string: %w", err)
+		return false, err
 	}
 
 	// determine the payload that is signed

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -433,7 +433,7 @@ func TestHooksLoadFromFile(t *testing.T) {
 
 	for _, tt := range hooksLoadFromFileTests {
 		h := &Hooks{}
-		err := h.LoadFromFile(tt.path, tt.asTemplate)
+		err := h.LoadFromFile(tt.path, tt.asTemplate, "")
 		if (err == nil) != tt.ok {
 			t.Errorf(err.Error())
 		}
@@ -450,7 +450,7 @@ func TestHooksTemplateLoadFromFile(t *testing.T) {
 		}
 
 		h := &Hooks{}
-		err := h.LoadFromFile(tt.path, tt.asTemplate)
+		err := h.LoadFromFile(tt.path, tt.asTemplate, "")
 		if (err == nil) != tt.ok {
 			t.Errorf(err.Error())
 			continue

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -274,7 +274,7 @@ var argumentGetTests = []struct {
 
 func TestArgumentGet(t *testing.T) {
 	for _, tt := range argumentGetTests {
-		a := Argument{tt.source, tt.name, "", false}
+		a := Argument{tt.source, tt.name, "", false, nil}
 		r := &Request{
 			Headers:    tt.headers,
 			Query:      tt.query,
@@ -294,14 +294,14 @@ var hookParseJSONParametersTests = []struct {
 	rheaders, rquery, rpayload map[string]interface{}
 	ok                         bool
 }{
-	{[]Argument{Argument{"header", "a", "", false}}, map[string]interface{}{"A": `{"b": "y"}`}, nil, nil, map[string]interface{}{"A": map[string]interface{}{"b": "y"}}, nil, nil, true},
-	{[]Argument{Argument{"url", "a", "", false}}, nil, map[string]interface{}{"a": `{"b": "y"}`}, nil, nil, map[string]interface{}{"a": map[string]interface{}{"b": "y"}}, nil, true},
-	{[]Argument{Argument{"payload", "a", "", false}}, nil, nil, map[string]interface{}{"a": `{"b": "y"}`}, nil, nil, map[string]interface{}{"a": map[string]interface{}{"b": "y"}}, true},
-	{[]Argument{Argument{"header", "z", "", false}}, map[string]interface{}{"Z": `{}`}, nil, nil, map[string]interface{}{"Z": map[string]interface{}{}}, nil, nil, true},
+	{[]Argument{Argument{"header", "a", "", false, nil}}, map[string]interface{}{"A": `{"b": "y"}`}, nil, nil, map[string]interface{}{"A": map[string]interface{}{"b": "y"}}, nil, nil, true},
+	{[]Argument{Argument{"url", "a", "", false, nil}}, nil, map[string]interface{}{"a": `{"b": "y"}`}, nil, nil, map[string]interface{}{"a": map[string]interface{}{"b": "y"}}, nil, true},
+	{[]Argument{Argument{"payload", "a", "", false, nil}}, nil, nil, map[string]interface{}{"a": `{"b": "y"}`}, nil, nil, map[string]interface{}{"a": map[string]interface{}{"b": "y"}}, true},
+	{[]Argument{Argument{"header", "z", "", false, nil}}, map[string]interface{}{"Z": `{}`}, nil, nil, map[string]interface{}{"Z": map[string]interface{}{}}, nil, nil, true},
 	// failures
-	{[]Argument{Argument{"header", "z", "", false}}, map[string]interface{}{"Z": ``}, nil, nil, map[string]interface{}{"Z": ``}, nil, nil, false},     // empty string
-	{[]Argument{Argument{"header", "y", "", false}}, map[string]interface{}{"X": `{}`}, nil, nil, map[string]interface{}{"X": `{}`}, nil, nil, false}, // missing parameter
-	{[]Argument{Argument{"string", "z", "", false}}, map[string]interface{}{"Z": ``}, nil, nil, map[string]interface{}{"Z": ``}, nil, nil, false},     // invalid argument source
+	{[]Argument{Argument{"header", "z", "", false, nil}}, map[string]interface{}{"Z": ``}, nil, nil, map[string]interface{}{"Z": ``}, nil, nil, false},     // empty string
+	{[]Argument{Argument{"header", "y", "", false, nil}}, map[string]interface{}{"X": `{}`}, nil, nil, map[string]interface{}{"X": `{}`}, nil, nil, false}, // missing parameter
+	{[]Argument{Argument{"string", "z", "", false, nil}}, map[string]interface{}{"Z": ``}, nil, nil, map[string]interface{}{"Z": ``}, nil, nil, false},     // invalid argument source
 }
 
 func TestHookParseJSONParameters(t *testing.T) {
@@ -326,9 +326,9 @@ var hookExtractCommandArgumentsTests = []struct {
 	value                   []string
 	ok                      bool
 }{
-	{"test", []Argument{Argument{"header", "a", "", false}}, map[string]interface{}{"A": "z"}, nil, nil, []string{"test", "z"}, true},
+	{"test", []Argument{Argument{"header", "a", "", false, nil}}, map[string]interface{}{"A": "z"}, nil, nil, []string{"test", "z"}, true},
 	// failures
-	{"fail", []Argument{Argument{"payload", "a", "", false}}, map[string]interface{}{"A": "z"}, nil, nil, []string{"fail", ""}, false},
+	{"fail", []Argument{Argument{"payload", "a", "", false, nil}}, map[string]interface{}{"A": "z"}, nil, nil, []string{"fail", ""}, false},
 }
 
 func TestHookExtractCommandArguments(t *testing.T) {
@@ -351,20 +351,21 @@ func TestHookExtractCommandArguments(t *testing.T) {
 // we test both cases where the name of the data is used as the name of the
 // env key & the case where the hook definition sets the env var name to a
 // fixed value using the envname construct like so::
-//    [
-//      {
-//        "id": "push",
-//        "execute-command": "bb2mm",
-//        "command-working-directory": "/tmp",
-//        "pass-environment-to-command":
-//        [
-//          {
-//            "source": "entire-payload",
-//            "envname": "PAYLOAD"
-//          },
-//        ]
-//      }
-//    ]
+//
+//	[
+//	  {
+//	    "id": "push",
+//	    "execute-command": "bb2mm",
+//	    "command-working-directory": "/tmp",
+//	    "pass-environment-to-command":
+//	    [
+//	      {
+//	        "source": "entire-payload",
+//	        "envname": "PAYLOAD"
+//	      },
+//	    ]
+//	  }
+//	]
 var hookExtractCommandArgumentsForEnvTests = []struct {
 	exec                    string
 	args                    []Argument
@@ -375,14 +376,14 @@ var hookExtractCommandArgumentsForEnvTests = []struct {
 	// successes
 	{
 		"test",
-		[]Argument{Argument{"header", "a", "", false}},
+		[]Argument{Argument{"header", "a", "", false, nil}},
 		map[string]interface{}{"A": "z"}, nil, nil,
 		[]string{"HOOK_a=z"},
 		true,
 	},
 	{
 		"test",
-		[]Argument{Argument{"header", "a", "MYKEY", false}},
+		[]Argument{Argument{"header", "a", "MYKEY", false, nil}},
 		map[string]interface{}{"A": "z"}, nil, nil,
 		[]string{"MYKEY=z"},
 		true,
@@ -390,7 +391,7 @@ var hookExtractCommandArgumentsForEnvTests = []struct {
 	// failures
 	{
 		"fail",
-		[]Argument{Argument{"payload", "a", "", false}},
+		[]Argument{Argument{"payload", "a", "", false, nil}},
 		map[string]interface{}{"A": "z"}, nil, nil,
 		[]string{},
 		false,
@@ -489,24 +490,24 @@ var matchRuleTests = []struct {
 	ok                                 bool
 	err                                bool
 }{
-	{"value", "", "", "z", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
-	{"regex", "^z", "", "z", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
-	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
+	{"value", "", "", "z", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
+	{"regex", "^z", "", "z", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
+	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
+	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
+	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
+	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
 	// failures
-	{"value", "", "", "X", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
-	{"regex", "^X", "", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
-	{"value", "", "2", "X", "", Argument{"header", "a", "", false}, map[string]interface{}{"Y": "z"}, nil, nil, []byte{}, "", false, true}, // reference invalid header
+	{"value", "", "", "X", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
+	{"regex", "^X", "", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
+	{"value", "", "2", "X", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"Y": "z"}, nil, nil, []byte{}, "", false, true}, // reference invalid header
 	// errors
-	{"regex", "*", "", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, true},                   // invalid regex
-	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
-	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
-	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hmac-sha512", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hash-sha512", "", "secret", "", "", Argument{"header", "a", "", false}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"regex", "*", "", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, true},                   // invalid regex
+	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
+	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
+	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"payload-hmac-sha512", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"payload-hash-sha512", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
 	// IP whitelisting, valid cases
 	{"ip-whitelist", "", "", "", "192.168.0.1/24", Argument{}, nil, nil, nil, []byte{}, "192.168.0.2:9000", true, false}, // valid IPv4, with range
 	{"ip-whitelist", "", "", "", "192.168.0.1/24", Argument{}, nil, nil, nil, []byte{}, "192.168.0.2:9000", true, false}, // valid IPv4, with range
@@ -552,8 +553,8 @@ var andRuleTests = []struct {
 	{
 		"(a=z, b=y): a=z && b=y",
 		AndRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "z", "B": "y"}, nil, nil,
 		[]byte{},
@@ -562,8 +563,8 @@ var andRuleTests = []struct {
 	{
 		"(a=z, b=Y): a=z && b=y",
 		AndRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "z", "B": "Y"}, nil, nil,
 		[]byte{},
@@ -573,22 +574,22 @@ var andRuleTests = []struct {
 	{
 		"(a=z, b=y, c=x, d=w=, e=X, f=X): a=z && (b=y && c=x) && (d=w || e=v) && !f=u",
 		AndRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
 			{
 				And: &AndRule{
-					{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
-					{Match: &MatchRule{"value", "", "", "x", Argument{"header", "c", "", false}, ""}},
+					{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
+					{Match: &MatchRule{"value", "", "", "x", Argument{"header", "c", "", false, nil}, ""}},
 				},
 			},
 			{
 				Or: &OrRule{
-					{Match: &MatchRule{"value", "", "", "w", Argument{"header", "d", "", false}, ""}},
-					{Match: &MatchRule{"value", "", "", "v", Argument{"header", "e", "", false}, ""}},
+					{Match: &MatchRule{"value", "", "", "w", Argument{"header", "d", "", false, nil}, ""}},
+					{Match: &MatchRule{"value", "", "", "v", Argument{"header", "e", "", false, nil}, ""}},
 				},
 			},
 			{
 				Not: &NotRule{
-					Match: &MatchRule{"value", "", "", "u", Argument{"header", "f", "", false}, ""},
+					Match: &MatchRule{"value", "", "", "u", Argument{"header", "f", "", false, nil}, ""},
 				},
 			},
 		},
@@ -600,7 +601,7 @@ var andRuleTests = []struct {
 	// failures
 	{
 		"invalid rule",
-		AndRule{{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false}, ""}}},
+		AndRule{{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false, nil}, ""}}},
 		map[string]interface{}{"Y": "z"}, nil, nil, nil,
 		false, true,
 	},
@@ -632,8 +633,8 @@ var orRuleTests = []struct {
 	{
 		"(a=z, b=X): a=z || b=y",
 		OrRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "z", "B": "X"}, nil, nil,
 		[]byte{},
@@ -642,8 +643,8 @@ var orRuleTests = []struct {
 	{
 		"(a=X, b=y): a=z || b=y",
 		OrRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "X", "B": "y"}, nil, nil,
 		[]byte{},
@@ -652,8 +653,8 @@ var orRuleTests = []struct {
 	{
 		"(a=Z, b=Y): a=z || b=y",
 		OrRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
-			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
+			{Match: &MatchRule{"value", "", "", "y", Argument{"header", "b", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"A": "Z", "B": "Y"}, nil, nil,
 		[]byte{},
@@ -663,7 +664,7 @@ var orRuleTests = []struct {
 	{
 		"missing parameter node",
 		OrRule{
-			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}},
+			{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}},
 		},
 		map[string]interface{}{"Y": "Z"}, nil, nil,
 		[]byte{},
@@ -694,8 +695,8 @@ var notRuleTests = []struct {
 	ok                      bool
 	err                     bool
 }{
-	{"(a=z): !a=X", NotRule{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false}, ""}}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, true, false},
-	{"(a=z): !a=z", NotRule{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false}, ""}}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, false, false},
+	{"(a=z): !a=X", NotRule{Match: &MatchRule{"value", "", "", "X", Argument{"header", "a", "", false, nil}, ""}}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, true, false},
+	{"(a=z): !a=z", NotRule{Match: &MatchRule{"value", "", "", "z", Argument{"header", "a", "", false, nil}, ""}}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, false, false},
 }
 
 func TestNotRule(t *testing.T) {

--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -40,100 +40,6 @@ func TestGetParameter(t *testing.T) {
 	}
 }
 
-var checkPayloadSignatureTests = []struct {
-	payload   []byte
-	secret    string
-	signature string
-	mac       string
-	ok        bool
-}{
-	{[]byte(`{"a": "z"}`), "secret", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", true},
-	{[]byte(`{"a": "z"}`), "secret", "sha1=b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", true},
-	{[]byte(`{"a": "z"}`), "secret", "sha1=XXXe04cbb22afa8ffbff8796fc1894ed27badd9e,sha1=b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", true},
-	{[]byte(``), "secret", "25af6174a0fcecc4d346680a72b7ce644b9a88e8", "25af6174a0fcecc4d346680a72b7ce644b9a88e8", true},
-	// failures
-	{[]byte(`{"a": "z"}`), "secret", "XXXe04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", false},
-	{[]byte(`{"a": "z"}`), "secret", "sha1=XXXe04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", false},
-	{[]byte(`{"a": "z"}`), "secret", "sha1=XXXe04cbb22afa8ffbff8796fc1894ed27badd9e,sha1=XXXe04cbb22afa8ffbff8796fc1894ed27badd9e", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", false},
-	{[]byte(`{"a": "z"}`), "secreX", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "900225703e9342328db7307692736e2f7cc7b36e", false},
-	{[]byte(`{"a": "z"}`), "", "b17e04cbb22afa8ffbff8796fc1894ed27badd9e", "", false},
-	{[]byte(``), "secret", "XXXf6174a0fcecc4d346680a72b7ce644b9a88e8", "25af6174a0fcecc4d346680a72b7ce644b9a88e8", false},
-}
-
-func TestCheckPayloadSignature(t *testing.T) {
-	for _, tt := range checkPayloadSignatureTests {
-		mac, err := CheckPayloadSignature(tt.payload, tt.secret, tt.signature)
-		if (err == nil) != tt.ok || mac != tt.mac {
-			t.Errorf("failed to check payload signature {%q, %q, %q}:\nexpected {mac:%#v, ok:%#v},\ngot {mac:%#v, ok:%#v}", tt.payload, tt.secret, tt.signature, tt.mac, tt.ok, mac, (err == nil))
-		}
-
-		if err != nil && tt.mac != "" && strings.Contains(err.Error(), tt.mac) {
-			t.Errorf("error message should not disclose expected mac: %s", err)
-		}
-	}
-}
-
-var checkPayloadSignature256Tests = []struct {
-	payload   []byte
-	secret    string
-	signature string
-	mac       string
-	ok        bool
-}{
-	{[]byte(`{"a": "z"}`), "secret", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", true},
-	{[]byte(`{"a": "z"}`), "secret", "sha256=f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", true},
-	{[]byte(`{"a": "z"}`), "secret", "sha256=XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89,sha256=f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", true},
-	{[]byte(``), "secret", "f9e66e179b6747ae54108f82f8ade8b3c25d76fd30afde6c395822c530196169", "f9e66e179b6747ae54108f82f8ade8b3c25d76fd30afde6c395822c530196169", true},
-	// failures
-	{[]byte(`{"a": "z"}`), "secret", "XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", false},
-	{[]byte(`{"a": "z"}`), "secret", "sha256=XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", false},
-	{[]byte(`{"a": "z"}`), "secret", "sha256=XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89,sha256=XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", false},
-	{[]byte(`{"a": "z"}`), "", "XXX7af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89", "", false},
-	{[]byte(``), "secret", "XXX66e179b6747ae54108f82f8ade8b3c25d76fd30afde6c395822c530196169", "f9e66e179b6747ae54108f82f8ade8b3c25d76fd30afde6c395822c530196169", false},
-}
-
-func TestCheckPayloadSignature256(t *testing.T) {
-	for _, tt := range checkPayloadSignature256Tests {
-		mac, err := CheckPayloadSignature256(tt.payload, tt.secret, tt.signature)
-		if (err == nil) != tt.ok || mac != tt.mac {
-			t.Errorf("failed to check payload signature {%q, %q, %q}:\nexpected {mac:%#v, ok:%#v},\ngot {mac:%#v, ok:%#v}", tt.payload, tt.secret, tt.signature, tt.mac, tt.ok, mac, (err == nil))
-		}
-
-		if err != nil && tt.mac != "" && strings.Contains(err.Error(), tt.mac) {
-			t.Errorf("error message should not disclose expected mac: %s", err)
-		}
-	}
-}
-
-var checkPayloadSignature512Tests = []struct {
-	payload   []byte
-	secret    string
-	signature string
-	mac       string
-	ok        bool
-}{
-	{[]byte(`{"a": "z"}`), "secret", "4ab17cc8ec668ead8bf498f87f8f32848c04d5ca3c9bcfcd3db9363f0deb44e580b329502a7fdff633d4d8fca301cc5c94a55a2fec458c675fb0ff2655898324", "4ab17cc8ec668ead8bf498f87f8f32848c04d5ca3c9bcfcd3db9363f0deb44e580b329502a7fdff633d4d8fca301cc5c94a55a2fec458c675fb0ff2655898324", true},
-	{[]byte(`{"a": "z"}`), "secret", "sha512=4ab17cc8ec668ead8bf498f87f8f32848c04d5ca3c9bcfcd3db9363f0deb44e580b329502a7fdff633d4d8fca301cc5c94a55a2fec458c675fb0ff2655898324", "4ab17cc8ec668ead8bf498f87f8f32848c04d5ca3c9bcfcd3db9363f0deb44e580b329502a7fdff633d4d8fca301cc5c94a55a2fec458c675fb0ff2655898324", true},
-	{[]byte(``), "secret", "b0e9650c5faf9cd8ae02276671545424104589b3656731ec193b25d01b07561c27637c2d4d68389d6cf5007a8632c26ec89ba80a01c77a6cdd389ec28db43901", "b0e9650c5faf9cd8ae02276671545424104589b3656731ec193b25d01b07561c27637c2d4d68389d6cf5007a8632c26ec89ba80a01c77a6cdd389ec28db43901", true},
-	// failures
-	{[]byte(`{"a": "z"}`), "secret", "74a0081f5b5988f4f3e8b8dd34dadc6291611f2e6260635a7e1535f8e95edb97ff520ba8b152e8ca5760ac42639854f3242e29efc81be73a8bf52d474d31ffea", "4ab17cc8ec668ead8bf498f87f8f32848c04d5ca3c9bcfcd3db9363f0deb44e580b329502a7fdff633d4d8fca301cc5c94a55a2fec458c675fb0ff2655898324", false},
-	{[]byte(`{"a": "z"}`), "", "74a0081f5b5988f4f3e8b8dd34dadc6291611f2e6260635a7e1535f8e95edb97ff520ba8b152e8ca5760ac42639854f3242e29efc81be73a8bf52d474d31ffea", "", false},
-	{[]byte(``), "secret", "XXX9650c5faf9cd8ae02276671545424104589b3656731ec193b25d01b07561c27637c2d4d68389d6cf5007a8632c26ec89ba80a01c77a6cdd389ec28db43901", "b0e9650c5faf9cd8ae02276671545424104589b3656731ec193b25d01b07561c27637c2d4d68389d6cf5007a8632c26ec89ba80a01c77a6cdd389ec28db43901", false},
-}
-
-func TestCheckPayloadSignature512(t *testing.T) {
-	for _, tt := range checkPayloadSignature512Tests {
-		mac, err := CheckPayloadSignature512(tt.payload, tt.secret, tt.signature)
-		if (err == nil) != tt.ok || mac != tt.mac {
-			t.Errorf("failed to check payload signature {%q, %q, %q}:\nexpected {mac:%#v, ok:%#v},\ngot {mac:%#v, ok:%#v}", tt.payload, tt.secret, tt.signature, tt.mac, tt.ok, mac, (err == nil))
-		}
-
-		if err != nil && tt.mac != "" && strings.Contains(err.Error(), tt.mac) {
-			t.Errorf("error message should not disclose expected mac: %s", err)
-		}
-	}
-}
-
 var checkScalrSignatureTests = []struct {
 	description       string
 	headers           map[string]interface{}
@@ -456,7 +362,7 @@ func TestHooksTemplateLoadFromFile(t *testing.T) {
 			continue
 		}
 
-		s := (*h.Match("webhook").TriggerRule.And)[0].Match.Secret
+		s := (*h.Match("webhook").TriggerRule.And)[0].Signature.Secret
 		if s != secret {
 			t.Errorf("Expected secret of %q, got %q", secret, s)
 		}
@@ -492,22 +398,12 @@ var matchRuleTests = []struct {
 }{
 	{"value", "", "", "z", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
 	{"regex", "^z", "", "z", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", true, false},
-	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
-	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), "", true, false},
 	// failures
 	{"value", "", "", "X", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
 	{"regex", "^X", "", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, false},
 	{"value", "", "2", "X", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"Y": "z"}, nil, nil, []byte{}, "", false, true}, // reference invalid header
 	// errors
-	{"regex", "*", "", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, true},                   // invalid regex
-	{"payload-hmac-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
-	{"payload-hash-sha1", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true},   // invalid hmac
-	{"payload-hmac-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hash-sha256", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hmac-sha512", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
-	{"payload-hash-sha512", "", "secret", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": ""}, nil, nil, []byte{}, "", false, true}, // invalid hmac
+	{"regex", "*", "", "", "", Argument{"header", "a", "", false, nil}, map[string]interface{}{"A": "z"}, nil, nil, []byte{}, "", false, true}, // invalid regex
 	// IP whitelisting, valid cases
 	{"ip-whitelist", "", "", "", "192.168.0.1/24", Argument{}, nil, nil, nil, []byte{}, "192.168.0.2:9000", true, false}, // valid IPv4, with range
 	{"ip-whitelist", "", "", "", "192.168.0.1/24", Argument{}, nil, nil, nil, []byte{}, "192.168.0.2:9000", true, false}, // valid IPv4, with range
@@ -533,6 +429,55 @@ func TestMatchRule(t *testing.T) {
 			Body:    tt.body,
 			RawRequest: &http.Request{
 				RemoteAddr: tt.remoteAddr,
+			},
+		}
+		ok, err := r.Evaluate(req)
+		if ok != tt.ok || (err != nil) != tt.err {
+			t.Errorf("%d failed to match %#v:\nexpected ok: %#v, err: %v\ngot ok: %#v, err: %v", i, r, tt.ok, tt.err, ok, err)
+		}
+	}
+}
+
+var signatureRuleTests = []struct {
+	algorithm, secret       string
+	sigSource               Argument
+	stringToSign            *Argument
+	headers, query, payload map[string]interface{}
+	body                    []byte
+	ok                      bool
+	err                     bool
+}{
+	{"sha1", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), true, false},
+	{"sha1", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": "b17e04cbb22afa8ffbff8796fc1894ed27badd9e"}, nil, nil, []byte(`{"a": "z"}`), true, false},
+	{"sha256", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), true, false},
+	{"sha256", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": "f417af3a21bd70379b5796d5f013915e7029f62c580fb0f500f59a35a6f04c89"}, nil, nil, []byte(`{"a": "z"}`), true, false},
+	// errors
+	{"sha1", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": ""}, nil, nil, []byte{}, false, true},   // invalid hmac
+	{"sha1", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": ""}, nil, nil, []byte{}, false, true},   // invalid hmac
+	{"sha256", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": ""}, nil, nil, []byte{}, false, true}, // invalid hmac
+	{"sha256", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": ""}, nil, nil, []byte{}, false, true}, // invalid hmac
+	{"sha512", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": ""}, nil, nil, []byte{}, false, true}, // invalid hmac
+	{"sha512", "secret", Argument{"header", "a", "", false, nil}, nil, map[string]interface{}{"A": ""}, nil, nil, []byte{}, false, true}, // invalid hmac
+
+	// template to build custom string-to-sign
+	{"sha256", "secret", Argument{"header", "a", "", false, nil}, &Argument{"template", "{{ printf \"%s\\n%s\" .BodyText (.GetHeader \"x-id\") }}", "", false, nil}, map[string]interface{}{"A": "sha256=4f1d62e6e6de1e31537a5faefabeffd7dce115bc499584feefbf8db6d2da4027", "X-Id": "test"}, nil, nil, []byte(`{"a": "z"}`), true, false},
+	{"sha256", "secret", Argument{"header", "a", "", false, nil}, &Argument{"template", "{{ printf \"%s\\n%s\" .BodyText (.GetHeader \"x-id\") }}", "", false, nil}, map[string]interface{}{"A": "sha256=4f1d62e6e6de1e31537a5faefabeffd7dce115bc499584feefbf8db6d2da4027", "X-Id": "unexpected"}, nil, nil, []byte(`{"a": "z"}`), false, true},
+}
+
+func TestSignatureRule(t *testing.T) {
+	for i, tt := range signatureRuleTests {
+		if tt.stringToSign != nil {
+			// post process the argument, as it would have been if it were loaded from a hooks file
+			tt.stringToSign.postProcess()
+		}
+		r := SignatureRule{tt.algorithm, tt.secret, tt.sigSource, "", tt.stringToSign}
+		req := &Request{
+			Headers: tt.headers,
+			Query:   tt.query,
+			Payload: tt.payload,
+			Body:    tt.body,
+			RawRequest: &http.Request{
+				RemoteAddr: "",
 			},
 		}
 		ok, err := r.Evaluate(req)

--- a/webhook.go
+++ b/webhook.go
@@ -39,6 +39,7 @@ var (
 	hooksURLPrefix     = flag.String("urlprefix", "hooks", "url prefix to use for served hooks (protocol://yourserver:port/PREFIX/:hook-id)")
 	secure             = flag.Bool("secure", false, "use HTTPS instead of HTTP")
 	asTemplate         = flag.Bool("template", false, "parse hooks file as a Go template")
+	templateDelimiters = flag.String("template-delims", "", "a comma-separated pair of delimiters, e.g. '((,))' or '[[,]]' to use instead of the standard '{{,}}' when parsing hooks file as a template, to avoid clashing with any \"source\": \"template\" arguments")
 	cert               = flag.String("cert", "cert.pem", "path to the HTTPS certificate pem file")
 	key                = flag.String("key", "key.pem", "path to the HTTPS certificate private key pem file")
 	justDisplayVersion = flag.Bool("version", false, "display webhook version and quit")
@@ -204,7 +205,7 @@ func main() {
 
 		newHooks := hook.Hooks{}
 
-		err := newHooks.LoadFromFile(hooksFilePath, *asTemplate)
+		err := newHooks.LoadFromFile(hooksFilePath, *asTemplate, *templateDelimiters)
 
 		if err != nil {
 			log.Printf("couldn't load hooks from file! %+v\n", err)
@@ -670,7 +671,7 @@ func reloadHooks(hooksFilePath string) {
 	// parse and swap
 	log.Printf("attempting to reload hooks from %s\n", hooksFilePath)
 
-	err := hooksInFile.LoadFromFile(hooksFilePath, *asTemplate)
+	err := hooksInFile.LoadFromFile(hooksFilePath, *asTemplate, *templateDelimiters)
 
 	if err != nil {
 		log.Printf("couldn't load hooks from file! %+v\n", err)


### PR DESCRIPTION
This started out as a more general fix for #643 but it has evolved into a larger refactor with a number of open questions, so I'm submitting it as a _draft_ PR initially for discussion:

## Overview

Issue #643 discusses the idea of verifying a signature that was computed over something other than just the request body content, and the related PR #644 provides an implementation of one special case of this general idea, concatenating one or more request header values to the end of the body data before calculating the signature.  However there are many variations on this theme, for example

- #455 talks about validating (rather complex) signatures over a string built up from several different request headers
- #512 the HMAC is computed over the body data but the signature value that you compare with has to be extracted as a _substring_ of one of the request headers, not the whole header value.
- #336 and #601 are not about signatures but still ask for a way to combine different parts of the payload into a single argument extraction

In this PR I've tried to come up with a general way to support cases like those as well.

The implementation is in two parts:

1. I've introduced a new `Argument` type `"source": "template"`, where the argument value is computed by evaluating a Go template against a context derived from the `Request`.  This lets you combine values from different headers, take substrings, etc.
2. I've refactored the various `payload-hmac-*` "match" rules into a new "check-signature" rule type, which gives the option to use an `Argument` for the "string-to-sign" as well as the one for the reference signature value.

Together these let you compute signatures over any combination of the body, headers and query parameters, concatenated together with no delimiter, newlines, colons, etc. as required by your particular webhook sender.

## Template argument type

```yaml
- source: template
  name: |
    {{- .BodyText -}}:{{- .GetHeader "x-request-id" -}}
```

The template argument type evaluates a Go template to build the argument value.  The template context gives access to all the things that the other argument types provide, including

- the raw payload (`.Body` as a `[]byte`, `.BodyText` as a string)
- the _parsed_ JSON/XML payload (`.Payload`)
- URL query parameters (`.Query`)
- request headers (the raw map as `.Headers`, but also the `.GetHeader "name"` function in the example above that canonicalises the header name the same way as a "source": "header" argument would do)
- webhook's own request ID (`.ID`)
- the remote address, content type and request method (`.RemoteAddr`, `.ContentType` and `.Method`)

I've deliberately _not_ exposed the whole of the `RawRequest` from the internal `Request` struct.

## The `check-signature` rule type

I've refactored all the `payload-hmac-sha1/256/512` match types into a new kind of rule.  The old

```json
{
  "match":
  {
    "type": "payload-hmac-<type>",
    "secret": "secret",
    "parameter":
    {
      "source": "header",
      "name": "X-Signature"
    }
  }
}
```

is now expressed as

```json
{
  "check-signature":
  {
    "algorithm": "<type>",
    "secret": "secret",
    "signature":
    {
      "source": "header",
      "name": "X-Signature"
    }
  }
}
```

However, as well as "algorithm", "secret" and "signature", you can now specify "string-to-sign" as another argument, which could be a simple argument like a single header

```json
{
  "check-signature":
  { "algorithm": "sha256", "secret": "secret",
    "signature":
    {
      "source": "header",
      "name": "X-Signature"
    },
    "string-to-sign":
    {
      "source": "header",
      "name": "Digest"
    }
  }
}
```

or it could be a template argument like the example above

```yaml
- check-signature:
    algorithm: sha256
    secret: my-secret
    signature:
      source: header
      name: x-signature
    string-to-sign:
      source: template
        name: |
          {{- .BodyText -}}:{{- .GetHeader "x-request-id" -}}
```

## Backwards compatibility

I've made sure that existing hooks files (YAML and JSON) will still parse as before, with the `payload-hmac-*` match rules being converted to `check-signature` rules during the loading process.  The only wrinkle is if you want to start using templates in arguments _and_ you need to parse the hooks file itself as a template, then it can get quite fiddly to escape the runtime templates from the parse-time engine.  To mitigate this I've added a `-template-delims` CLI option to change the delimiters used for the parse-time template engine, so you can say `-template-delims='[[,]]'` and then use `[[ getenv "..." ]]` for the parse-time template and `{{ .GetHeader "..." }}` for the runtime ones.

---

## Open questions for discussion

### Are Go Templates the right paradigm?

Go templates are very flexible, but should we stick with something simpler and with fewer gotchas around whitespace handling etc.?  #512 mentions cel-go as an alternative.

### Template context

Is the template context appropriate?  Are there other things we could/should expose to the templates, or more sensible names for the things that are already there?

Do we want to add some more useful _functions_ to the template engine?  One extreme would be to introduce something like [Sprig](https://masterminds.github.io/sprig/), the same function library used by Helm.  This includes functions for things like date parsing and formatting, which would also open up a way to use template arguments to check things like "is the Date header less than 15 minutes old":

```yaml
- match:
    type: "value"
    value: "yes"
    parameter:
      source: template
      name: |
        {{- if (.GetHeader "date" | toDate "Mon Jan 2 15:04:05 MST 2006").After (now | dateModify "-15m") -}}
          yes
        {{- end -}}
```

Though something like that probably deserves its own dedicated rule type.