### PR TITLE
fix: Trim the cat output

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -970,7 +970,7 @@ func cat(s string) string {
 		return ""
 	}
 
-	return string(data)
+	return strings.TrimSuffix(string(data), "\n")
 }
 
 // credential provides a template function to retreive secrets using systemd's LoadCredential mechanism


### PR DESCRIPTION
`os.ReadFile` includes a trailing EOL, so we have to remove it to get the correct value