### PR TITLE
Fix Gitea incoming webhook example and add a YAML version

### DIFF
--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -248,7 +248,7 @@ JSON version:
           "match":
           {
             "type": "payload-hmac-sha256",
-            "value": "mysecret",
+            "secret": "mysecret",
             "parameter":
             {
               "source": "header",


### PR DESCRIPTION
This PR fixes the Gitea incoming webhook example:

-  The `secret` field in the payload is deprecated as of Gitea 1.13.0 and no longer sent by recent versions, we use the `X-Gitea-Signature` header instead
- Gitea `DEFAULT_BRANCH` parameter is to set to `main` by default, the value of `ref` parameter has been updated accordingly
- `pusher.name` has been replaced by `pusher.full_name`

I’ve also added a YAML version of the example as there aren't many in the docs.