### PR TITLE
Docs: HTTP request parameters documented!

### DIFF
--- a/docs/Referencing-Request-Values.md
+++ b/docs/Referencing-Request-Values.md
@@ -20,6 +20,11 @@ There are four types of request values:
     ```
 
 3. HTTP Request parameters
+    #### Valid `name` Parameters:
+    - `"name": "method"`
+    - `"name": "remote-addr"`
+
+    *Note* Anything other than above mentioned `name` Parameters would be Invalid!
 
     ```json
     {

--- a/docs/Referencing-Request-Values.md
+++ b/docs/Referencing-Request-Values.md
@@ -24,7 +24,7 @@ There are four types of request values:
     - `"name": "method"`
     - `"name": "remote-addr"`
 
-    *Note* Anything other than above mentioned `name` Parameters would be Invalid!
+    *Note* Anything other than above mentioned `name` parameters would be invalid!
 
     ```json
     {


### PR DESCRIPTION
updated the documentation to clarify that only "method" and "remote-addr" are valid name values for the "request" parameter source. This addresses issue #732 and helps users understand the supported options when referencing HTTP request parameters.

Closes #732 