### PR TITLE
Added Printing the Raw Webhook Payload to Standard Output example

### DIFF
--- a/docs/Hook-Examples.md
+++ b/docs/Hook-Examples.md
@@ -24,6 +24,24 @@ although the examples on this page all use the JSON format.
 * [Receive Synology DSM notifications](#receive-synology-notifications)
 * [Incoming Azure Container Registry (ACR) webhook](#incoming-acr-webhook)
 
+## Printing the Raw Webhook Payload to Standard Output
+
+This hook configuration receives incoming webhook requests and prints the raw request body (payload) directly to the server's standard output (visible in the webhook process logs when running with -verbose). It is particularly useful for debugging and verifying webhook deliveries from external services.
+
+```json
+[
+  {
+    "id": "print-payload",
+    "execute-command": "/bin/echo",
+    "pass-arguments-to-command": [
+      {
+        "source": "entire-payload",
+      }
+    ]
+  }
+]
+```
+
 ## Incoming Github webhook
 
 This example works on 2.8+ versions of Webhook - if you are on a previous series, change `payload-hmac-sha1` to `payload-hash-sha1`.


### PR DESCRIPTION
This adds a minimal hook example to Hook-Examples.md for printing the raw incoming webhook payload directly to the server's console/output (visible in verbose logs).

This is particularly useful for:
- Quick testing and verification of webhook senders.
- Debugging payload content without writing custom scripts.

The example leverages `pass-raw-request-body` (introduced in v2.8.0) to pipe the raw body to stdin, combined with `/bin/cat -` to output it.

No code changes are required—pure documentation addition.

Example configuration:
```json
[
  {
    "id": "print-payload",
    "execute-command": "/bin/cat",
    "pass-raw-request-body": true,
    "pass-arguments-to-command": [
      {
        "source": "string",
        "name": "-"
      }
    ],
    "include-command-output-in-response": true,
    "include-command-output-in-response-on-error": true
  }
]