### PR TITLE
Add disable-command-output-logging hook property

### DIFF
--- a/internal/hook/hook.go
+++ b/internal/hook/hook.go
@@ -571,6 +571,7 @@ type Hook struct {
 	ResponseHeaders                     ResponseHeaders `json:"response-headers,omitempty"`
 	CaptureCommandOutput                bool            `json:"include-command-output-in-response,omitempty"`
 	CaptureCommandOutputOnError         bool            `json:"include-command-output-in-response-on-error,omitempty"`
+	DisableCommandOutputLogging         bool            `json:"disable-command-output-logging,omitempty"`
 	PassEnvironmentToCommand            []Argument      `json:"pass-environment-to-command,omitempty"`
 	PassArgumentsToCommand              []Argument      `json:"pass-arguments-to-command,omitempty"`
 	PassFileToCommand                   []Argument      `json:"pass-file-to-command,omitempty"`

--- a/webhook.go
+++ b/webhook.go
@@ -633,7 +633,9 @@ func handleHook(h *hook.Hook, r *hook.Request) (string, error) {
 
 	out, err := cmd.CombinedOutput()
 
-	log.Printf("[%s] command output: %s\n", r.ID, out)
+	if err != nil || !h.DisableCommandOutputLogging {
+		log.Printf("[%s] command output: %s\n", r.ID, out)
+	}
 
 	if err != nil {
 		log.Printf("[%s] error occurred: %+v\n", r.ID, err)

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -68,6 +68,70 @@ func TestStaticParams(t *testing.T) {
 	}
 }
 
+func TestDisableCommandOutputLogging(t *testing.T) {
+	hookecho, cleanHookecho := buildHookecho(t)
+	defer cleanHookecho()
+
+	tests := []struct {
+		name    string
+		hook    *hook.Hook
+		wantLog bool
+		wantErr bool
+	}{
+		{
+			name: "logs command output on success by default",
+			hook: &hook.Hook{
+				ExecuteCommand: hookecho,
+				PassArgumentsToCommand: []hook.Argument{
+					{Source: "string", Name: "passed"},
+				},
+			},
+			wantLog: true,
+		},
+		{
+			name: "does not log command output on success when disabled",
+			hook: &hook.Hook{
+				ExecuteCommand:              hookecho,
+				DisableCommandOutputLogging: true,
+				PassArgumentsToCommand: []hook.Argument{
+					{Source: "string", Name: "passed"},
+				},
+			},
+			wantLog: false,
+		},
+		{
+			name: "still logs command output on error when disabled",
+			hook: &hook.Hook{
+				ExecuteCommand:              hookecho,
+				DisableCommandOutputLogging: true,
+				PassArgumentsToCommand: []hook.Argument{
+					{Source: "string", Name: "exit=1"},
+				},
+			},
+			wantLog: true,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &bytes.Buffer{}
+			log.SetOutput(b)
+			t.Cleanup(func() { log.SetOutput(os.Stderr) })
+
+			_, err := handleHook(tt.hook, &hook.Request{ID: "test"})
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("handleHook() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			gotLog := strings.Contains(b.String(), "command output:")
+			if gotLog != tt.wantLog {
+				t.Fatalf("command output logged = %v, want %v\nlog output:\n%s", gotLog, tt.wantLog, b.String())
+			}
+		})
+	}
+}
+
 func TestWebhook(t *testing.T) {
 	hookecho, cleanupHookecho := buildHookecho(t)
 	defer cleanupHookecho()


### PR DESCRIPTION
## Summary
- Adds per-hook `disable-command-output-logging` boolean property
- When `true`, suppresses `command output:` log line on successful executions
- Errors are still logged (backward compatible default: `false`)

Fixes #680

## Test plan
- [x] `go test -run TestDisableCommandOutputLogging -v`
- [x] `go test ./...`