### PR TITLE
ci: update Go matrix for macOS 26

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,15 +10,19 @@ jobs:
       # one that the Go command has upgraded to automatically.
       GOTOOLCHAIN: local
     strategy:
+      fail-fast: false
       matrix:
         go-version: [1.21.x, 1.22.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest]
+        include:
+          - go-version: 1.26.x
+            os: macos-latest
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
         with:
           go-version: ${{ matrix.go-version }}
         id: go


### PR DESCRIPTION
## Summary

- keep Go 1.21 and 1.22 compatibility coverage on Ubuntu and Windows
- run Go 1.26 on `macos-latest`, which now resolves to macOS 26
- disable matrix fail-fast so one platform does not hide other results
- update `actions/checkout` and `actions/setup-go` to v7

## Background

The latest master run failed in the macOS jobs after GitHub migrated `macos-latest` to macOS 26. Go versions before 1.24 do not generate the Mach-O `LC_UUID` required by newer macOS network privacy behavior, while the webhook integration tests bind loopback ports.

## Validation

- `go test ./...`
- YAML syntax validation
- `git diff --check`