### PR TITLE
test: fix non-constant Errorf format strings

### DIFF
--- a/internal/hook/hook_test.go
+++ b/internal/hook/hook_test.go
@@ -434,7 +434,7 @@ func TestHooksLoadFromFile(t *testing.T) {
 		h := &Hooks{}
 		err := h.LoadFromFile(tt.path, tt.asTemplate)
 		if (err == nil) != tt.ok {
-			t.Errorf(err.Error())
+			t.Errorf("%s", err)
 		}
 	}
 }
@@ -451,7 +451,7 @@ func TestHooksTemplateLoadFromFile(t *testing.T) {
 		h := &Hooks{}
 		err := h.LoadFromFile(tt.path, tt.asTemplate)
 		if (err == nil) != tt.ok {
-			t.Errorf(err.Error())
+			t.Errorf("%s", err)
 			continue
 		}
 


### PR DESCRIPTION
This change will solve future problems with newer Go releases:

~~~
go test ./...
# github.com/adnanh/webhook/internal/hook
# [github.com/adnanh/webhook/internal/hook]
internal/hook/hook_test.go:437:13: non-constant format string in call to (*testing.common).Errorf
internal/hook/hook_test.go:454:13: non-constant format string in call to (*testing.common).Errorf
ok  	github.com/adnanh/webhook	16.256s
FAIL	github.com/adnanh/webhook/internal/hook [build failed]
?   	github.com/adnanh/webhook/internal/middleware	[no test files]
ok  	github.com/adnanh/webhook/internal/pidfile	0.005s
?   	github.com/adnanh/webhook/test	[no test files]
FAIL
~~~