### PR TITLE
refactor: replace deprecated io/ioutil usage

### DIFF
--- a/internal/pidfile/pidfile.go
+++ b/internal/pidfile/pidfile.go
@@ -5,7 +5,6 @@ package pidfile
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -18,7 +17,7 @@ type PIDFile struct {
 }
 
 func checkPIDFileAlreadyExists(path string) error {
-	if pidByte, err := ioutil.ReadFile(path); err == nil {
+	if pidByte, err := os.ReadFile(path); err == nil {
 		pidString := strings.TrimSpace(string(pidByte))
 		if pid, err := strconv.Atoi(pidString); err == nil {
 			if processExists(pid) {
@@ -38,7 +37,7 @@ func New(path string) (*PIDFile, error) {
 	if err := MkdirAll(filepath.Dir(path), os.FileMode(0o755)); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(path, []byte(fmt.Sprintf("%d", os.Getpid())), 0o600); err != nil {
+	if err := os.WriteFile(path, []byte(fmt.Sprintf("%d", os.Getpid())), 0o600); err != nil {
 		return nil, err
 	}
 

--- a/internal/pidfile/pidfile_test.go
+++ b/internal/pidfile/pidfile_test.go
@@ -1,14 +1,13 @@
 package pidfile
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
 )
 
 func TestNewAndRemove(t *testing.T) {
-	dir, err := ioutil.TempDir(os.TempDir(), "test-pidfile")
+	dir, err := os.MkdirTemp(os.TempDir(), "test-pidfile")
 	if err != nil {
 		t.Fatal("Could not create test directory")
 	}

--- a/testutils.go
+++ b/testutils.go
@@ -5,7 +5,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -13,7 +12,7 @@ import (
 )
 
 func prepareTestSocket(_ string) (socketPath string, transport *http.Transport, cleanup func(), err error) {
-	tmp, err := ioutil.TempDir("", "webhook-socket-")
+	tmp, err := os.MkdirTemp("", "webhook-socket-")
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/webhook.go
+++ b/webhook.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -172,7 +172,7 @@ func main() {
 	}
 
 	if !*verbose {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 
 	// Create pidfile
@@ -379,7 +379,7 @@ func hookHandler(w http.ResponseWriter, r *http.Request) {
 	isMultipart := strings.HasPrefix(req.ContentType, "multipart/form-data;")
 
 	if !isMultipart {
-		req.Body, err = ioutil.ReadAll(r.Body)
+		req.Body, err = io.ReadAll(r.Body)
 		if err != nil {
 			log.Printf("[%s] error reading the request body: %+v\n", req.ID, err)
 		}
@@ -608,7 +608,7 @@ func handleHook(h *hook.Hook, r *hook.Request) (string, error) {
 	}
 
 	for i := range files {
-		tmpfile, err := ioutil.TempFile(h.CommandWorkingDirectory, files[i].EnvName)
+		tmpfile, err := os.CreateTemp(h.CommandWorkingDirectory, files[i].EnvName)
 		if err != nil {
 			log.Printf("[%s] error creating temp file [%s]", r.ID, err)
 			continue

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net"
 	"net/http"
@@ -34,7 +34,7 @@ func TestStaticParams(t *testing.T) {
 
 	// case 2: binary with spaces in its name
 	d1 := []byte("#!/bin/sh\n/bin/echo\n")
-	err := ioutil.WriteFile("/tmp/with space", d1, 0755)
+	err := os.WriteFile("/tmp/with space", d1, 0755)
 	if err != nil {
 		t.Fatalf("%v", err)
 	}
@@ -103,7 +103,7 @@ func TestWebhook(t *testing.T) {
 
 			url := fmt.Sprintf("http://%s/hooks/%s", authority, tt.id)
 
-			req, err := http.NewRequest(tt.method, url, ioutil.NopCloser(strings.NewReader(tt.body)))
+			req, err := http.NewRequest(tt.method, url, io.NopCloser(strings.NewReader(tt.body)))
 			if err != nil {
 				t.Errorf("New request failed: %s", err)
 			}
@@ -122,7 +122,7 @@ func TestWebhook(t *testing.T) {
 				t.Errorf("client.Do failed: %s", err)
 			}
 
-			body, err := ioutil.ReadAll(res.Body)
+			body, err := io.ReadAll(res.Body)
 			res.Body.Close()
 			if err != nil {
 				t.Errorf("POST %q: failed to ready body: %s", tt.desc, err)
@@ -199,7 +199,7 @@ func TestWebhook(t *testing.T) {
 }
 
 func buildHookecho(t *testing.T) (binPath string, cleanupFn func()) {
-	tmp, err := ioutil.TempDir("", "hookecho-test-")
+	tmp, err := os.MkdirTemp("", "hookecho-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -226,7 +226,7 @@ func buildHookecho(t *testing.T) (binPath string, cleanupFn func()) {
 func genConfig(t *testing.T, bin, hookTemplate string) (configPath string, cleanupFn func()) {
 	tmpl := template.Must(template.ParseFiles(hookTemplate))
 
-	tmp, err := ioutil.TempDir("", "webhook-config-")
+	tmp, err := os.MkdirTemp("", "webhook-config-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -258,7 +258,7 @@ func genConfig(t *testing.T, bin, hookTemplate string) (configPath string, clean
 }
 
 func buildWebhook(t *testing.T) (binPath string, cleanupFn func()) {
-	tmp, err := ioutil.TempDir("", "webhook-test-")
+	tmp, err := os.MkdirTemp("", "webhook-test-")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
From Go [documentation](https://pkg.go.dev/io/ioutil): 

"As of Go 1.16, the same functionality is now provided by package [io](https://pkg.go.dev/io) or package [os](https://pkg.go.dev/os), and those implementations should be preferred in new code."