### PR TITLE
Remove dead Faircode and Flattr donation links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,6 @@ This project exists thanks to all the people who contribute. [Contribute!](CONTR
  - [OpenCollective Sponsor](https://opencollective.com/webhook#sponsor)
  - [PayPal](https://paypal.me/hookdoo)
  - [Patreon](https://www.patreon.com/webhook)
- - [Faircode](https://faircode.io/product/webhook?utm_source=badge&utm_medium=badgelarge&utm_campaign=webhook)
- - [Flattr](https://flattr.com/submit/auto?user_id=adnanh&url=https%3A%2F%2Fwww.github.com%2Fadnanh%2Fwebhook)
 
 ---
 


### PR DESCRIPTION
Two donation links in the README point at services that no longer exist:

- **Faircode** — `faircode.io/product/webhook` returns 404; faircode.io now hosts the fair-code licensing-model site with no per-project donation pages.
- **Flattr** — the Flattr service was discontinued entirely (its own root page serves "404 | Service No Longer Exists").

Removed both bullets; the remaining donation options are untouched.
